### PR TITLE
Added category and developer keys for use with munki 2.

### DIFF
--- a/Airfoil/Airfoil.munki.recipe
+++ b/Airfoil/Airfoil.munki.recipe
@@ -10,6 +10,8 @@
         <dict>
             <key>MUNKI_REPO_SUBDIR</key>
             <string>apps/airfoil</string>
+            <key>MUNKI_CATEGORY</key>
+            <string>Media</string>
             <key>NAME</key>
             <string>Airfoil</string>
             <key>pkginfo</key>
@@ -44,7 +46,7 @@ fi
                 <key>developer</key>
                 <string>Rogue Amoeba</string>
                 <key>category</key>
-                <string>Media</string>
+                <string>%MUNKI_CATEGORY%</string>
             </dict>
         </dict>
         <key>MinimumVersion</key>

--- a/Calibre/Calibre.munki.recipe
+++ b/Calibre/Calibre.munki.recipe
@@ -10,6 +10,8 @@
     <dict>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/calibre</string>
+        <key>MUNKI_CATEGORY</key>
+        <string>eBooks</string>
         <key>NAME</key>
         <string>Calibre</string>
         <key>pkginfo</key>
@@ -18,8 +20,12 @@
             <array>
                 <string>testing</string>
             </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
             <key>description</key>
             <string>Calibre is a free and open source e-book library management application.</string>
+            <key>developer</key>
+            <string>Kovid Goyal</string>
             <key>display_name</key>
             <string>Calibre</string>
             <key>name</key>

--- a/Clementine/Clementine.munki.recipe
+++ b/Clementine/Clementine.munki.recipe
@@ -10,6 +10,8 @@
     <dict>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Clementine</string>
+        <key>MUNKI_CATEGORY</key>
+        <string>Media</string>
         <key>NAME</key>
         <string>Clementine</string>
         <key>pkginfo</key>
@@ -18,8 +20,12 @@
             <array>
                 <string>testing</string>
             </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
             <key>description</key>
             <string>Clementine is a modern music player and library organizer.</string>
+            <key>developer</key>
+            <string>David Sansome, John Maguire and Arnaud Bienner</string>
             <key>display_name</key>
             <string>Clementine</string>
             <key>name</key>

--- a/Postbox/Postbox.munki.recipe
+++ b/Postbox/Postbox.munki.recipe
@@ -10,6 +10,8 @@
     <dict>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/Postbox</string>
+        <key>MUNKI_CATEGORY</key>
+        <string>Mail Clients</string>
         <key>NAME</key>
         <string>Postbox</string>
         <key>pkginfo</key>
@@ -18,8 +20,12 @@
             <array>
                 <string>testing</string>
             </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
             <key>description</key>
             <string>Powerful, intuitive, and faster than a scalded monkey, the Postbox email client will help you stay on task, find information quickly and act, not react.</string>
+            <key>developer</key>
+            <string>Postbox, Inc.</string>
             <key>display_name</key>
             <string>Postbox</string>
             <key>name</key>

--- a/VagrantManager/VagrantManager.munki.recipe
+++ b/VagrantManager/VagrantManager.munki.recipe
@@ -10,6 +10,8 @@
     <dict>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps</string>
+        <key>MUNKI_CATEGORY</key>
+        <string>Utilities</string>
         <key>NAME</key>
         <string>VagrantManager</string>
         <key>pkginfo</key>
@@ -18,8 +20,12 @@
             <array>
                 <string>testing</string>
             </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
             <key>description</key>
             <string>Vagrant Manager is an OS X status bar menu app that lets you manage all of your vagrant machines from one central location.</string>
+            <key>developer</key>
+            <string>Lanayo Technologies</string>
             <key>display_name</key>
             <string>Vagrant Manager</string>
             <key>name</key>

--- a/Versions/Versions.munki.recipe
+++ b/Versions/Versions.munki.recipe
@@ -12,14 +12,20 @@
         <string>Versions</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps</string>
+        <key>MUNKI_CATEGORY</key>
+        <string>Development</string>
         <key>pkginfo</key>
         <dict>
             <key>catalogs</key>
             <array>
                 <string>testing</string>
             </array>
+            <key>category</key>
+            <string>%MUNKI_CATEGORY%</string>
             <key>description</key>
             <string>Subversion client for Mac.</string>
+            <key>developer</key>
+            <string>Black Pixel</string>
             <key>display_name</key>
             <string>Versions</string>
             <key>name</key>

--- a/Widelands/Widelands.munki.recipe
+++ b/Widelands/Widelands.munki.recipe
@@ -10,6 +10,8 @@
 		<dict>
 			<key>MUNKI_REPO_SUBDIR</key>
 			<string>games/Widelands</string>
+			<key>MUNKI_CATEGORY</key>
+			<string>Games</string>
 			<key>NAME</key>
 			<string>Widelands</string>
 			<key>pkginfo</key>
@@ -18,8 +20,12 @@
 				<array>
 					<string>testing</string>
 				</array>
+				<key>category</key>
+				<string>%MUNKI_CATEGORY%</string>
 				<key>description</key>
 				<string>Widelands is a free, open source real-time strategy game with singleplayer campaigns and a multiplayer mode.</string>
+				<key>developer</key>
+				<string>Widelands Development Team</string>
 				<key>display_name</key>
 				<string>Widelands</string>
 				<key>name</key>


### PR DESCRIPTION
The Airfoil recipe had category and developer keys; I moved the category from being coded in the pkginfo key to being a stand alone input variable to allow for easy local overrides.
