### PR TITLE
Update node.verify for SHA256 verification

### DIFF
--- a/Node.js/Sha256sumVerifier.py
+++ b/Node.js/Sha256sumVerifier.py
@@ -19,19 +19,19 @@ from autopkglib import Processor, ProcessorError
 import hashlib
 
 
-__all__ = ["Sha1sumVerifier"]
+__all__ = ["Sha256sumVerifier"]
 
 
-class Sha1sumVerifier(Processor):
-    description = "Verifies sha1sum of package against a given SHA1 checksum. Throws a ProcessorError on mismatch."
+class Sha256sumVerifier(Processor):
+    description = "Verifies sha256sum of package against a given SHA256 checksum. Throws a ProcessorError on mismatch."
     input_variables = {
         "pkgpath": {
             "required": True,
             "description": "Package to checksum.",
         },
-        "expected_sha1sum": {
+        "expected_sha256sum": {
             "required": True,
-            "description": "Expected SHA1 checksum.",
+            "description": "Expected SHA256 checksum.",
         },
     }
     output_variables = {
@@ -40,31 +40,31 @@ class Sha1sumVerifier(Processor):
     __doc__ = description
     
     
-    def sha1sum_from_pkg(self, pkgpath):
-        sha1 = hashlib.sha1()
+    def sha256sum_from_pkg(self, pkgpath):
+        sha256 = hashlib.sha256()
         f = open(pkgpath, 'rb')
         try:
-            sha1.update(f.read())
+            sha256.update(f.read())
         finally:
             f.close()
-        return sha1.hexdigest()
+        return sha256.hexdigest()
     
     
     def main(self):
         pkgpath = self.env['pkgpath']
         self.output('Using pkgpath %s' % pkgpath)
-        expected = self.env['expected_sha1sum']
-        self.output('Using expected SHA1 checksum %s' % expected)
+        expected = self.env['expected_sha256sum']
+        self.output('Using expected SHA256 checksum %s' % expected)
 
-        sha1sum_from_pkg = self.sha1sum_from_pkg(pkgpath)
-        self.output('SHA1 for %s: %s' % (pkgpath, sha1sum_from_pkg))
-        if sha1sum_from_pkg == expected:
-            self.output("SHA1 checksum matches")
+        sha256sum_from_pkg = self.sha256sum_from_pkg(pkgpath)
+        self.output('SHA256 for %s: %s' % (pkgpath, sha256sum_from_pkg))
+        if sha256sum_from_pkg == expected:
+            self.output("SHA256 checksum matches")
         else:
-            raise ProcessorError("SHA1 checksum mismatch")
+            raise ProcessorError("SHA256 checksum mismatch")
    
 
 if __name__ == '__main__':
-    processor = Sha1sumVerifier()
+    processor = Sha256sumVerifier()
     processor.execute_shell()
     

--- a/Node.js/node.verify.recipe
+++ b/Node.js/node.verify.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Verifies the SHA1 checksum of the latest version of Node.js.</string>
+        <string>Verifies the SHA256 checksum of the latest version of Node.js.</string>
         <key>Identifier</key>
         <string>com.github.gerardkok.verify.node</string>
         <key>Input</key>
@@ -23,7 +23,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>url</key>
-                    <string>https://nodejs.org/dist/v%version%/SHASUMS.txt</string>
+                    <string>https://nodejs.org/dist/v%version%/SHASUMS256.txt</string>
                     <key>re_pattern</key>
                     <string>^([0-9a-f]+)\s+%NAME%-v%version%.pkg$</string>
                     <key>re_flags</key>
@@ -31,18 +31,18 @@
                         <string>MULTILINE</string>
                     </array>
                     <key>result_output_var_name</key>
-                    <string>expected_sha1sum</string>
+                    <string>expected_sha256sum</string>
                 </dict>
             </dict>
             <dict>
                 <key>Processor</key>
-                <string>Sha1sumVerifier</string>
+                <string>Sha256sumVerifier</string>
                 <key>Arguments</key>
                 <dict>
                     <key>pkgpath</key>
                     <string>%pathname%</string>
-                    <key>expected_sha1sum</key>
-                    <string>%expected_sha1sum%</string>
+                    <key>expected_sha256sum</key>
+                    <string>%expected_sha256sum%</string>
                 </dict>
             </dict>
         </array>


### PR DESCRIPTION
I noticed this alongside the v4.0.0 announcement. I opted to just switch all SHA1 to SHA256 as it's only used in this node recipe.