### PR TITLE
Update regular expression for new version

### DIFF
--- a/GPGTools/GPGSuite.download.recipe
+++ b/GPGTools/GPGSuite.download.recipe
@@ -23,7 +23,7 @@
                     <key>url</key>
                     <string>https://gpgtools.org/gpgsuite.html</string>
                     <key>re_pattern</key>
-                    <string>href=\"https://releases.gpgtools.org/GPG_Suite-([0-9a-z\.\-]+)\.dmg\"</string>
+                    <string>href=\"https://releases.gpgtools.org/GPG_Suite-([0-9a-z\.\-_]+)\.dmg\"</string>
                     <key>result_output_var_name</key>
                     <string>version</string>
                 </dict>


### PR DESCRIPTION
Overnight our build of the GPGSuite failed saying:

       Processor: URLTextSearcher: Error: No match found on URL

This is because there has been a new release of the suite (GPG Suite
2016.07 July 4th, 2016 according to the release notes which has version number:

       2016.07_v2

so the regular expression:

    href=\"https://releases.gpgtools.org/GPG_Suite-([0-9a-z\.\-]+)\.dmg\"

was not matching (as it didn't include the underscore character).

This patch just adds the underscore character to the regular expression,
meaning the download now succeeds.