### PR TITLE
update dev id

### DIFF
--- a/Versions/Versions.download.recipe
+++ b/Versions/Versions.download.recipe
@@ -59,7 +59,7 @@
                     <string>%RECIPE_CACHE_DIR%/%NAME%/Versions.app</string>
                     <key>expected_authority_names</key>
                     <array>
-                        <string>Developer ID Application: Black Pixel</string>
+                        <string>Developer ID Application: Black Pixel (432ZXYXDNY)</string>
                         <string>Developer ID Certification Authority</string>
                         <string>Apple Root CA</string>
                     </array>


### PR DESCRIPTION
the latest version it will now download is for 10.12 and up, no longer for MacOS10.11.x