### PR TITLE
Replaced expected_authority_names with requirement string

### DIFF
--- a/Postbox/Postbox.download.recipe
+++ b/Postbox/Postbox.download.recipe
@@ -48,12 +48,10 @@
                 <dict>
                     <key>input_path</key>
                     <string>%pathname%/Postbox.app</string>
-                    <key>expected_authority_names</key>
-                    <array>
-                        <string>Developer ID Application: Postbox, Inc. (A9QD7F9VSC)</string>
-                        <string>Developer ID Certification Authority</string>
-                        <string>Apple Root CA</string>
-                    </array>
+                    <key>requirement</key>
+                    <string>identifier "com.postbox-inc.postbox" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = A9QD7F9VSC</string>
+                    <key>strict_verification</key>
+                    <true />
                 </dict>
                 <key>Processor</key>
                 <string>CodeSignatureVerifier</string>

--- a/Versions/Versions.download.recipe
+++ b/Versions/Versions.download.recipe
@@ -57,12 +57,10 @@
                 <dict>
                     <key>input_path</key>
                     <string>%RECIPE_CACHE_DIR%/%NAME%/Versions.app</string>
-                    <key>expected_authority_names</key>
-                    <array>
-                        <string>Developer ID Application: Black Pixel (432ZXYXDNY)</string>
-                        <string>Developer ID Certification Authority</string>
-                        <string>Apple Root CA</string>
-                    </array>
+                    <key>requirement</key>
+                    <string>anchor apple generic and identifier "com.blackpixel.versions" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "432ZXYXDNY")</string>
+                    <key>strict_verification</key>
+                    <true />
                 </dict>
                 <key>Processor</key>
                 <string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Using `expected_authority_names` for verifying .app bundles is not supported in AutoPkg 1.0.3.