### PR TITLE
Utilize uninstall_script

### DIFF
--- a/Jenkins/Jenkins.munki.recipe
+++ b/Jenkins/Jenkins.munki.recipe
@@ -57,8 +57,13 @@
                 <key>preinstall_script</key>
                 <string>#!/bin/sh
 
-/bin/launchctl unload /Library/LaunchDaemons/org.jenkins-ci.plist               
-</string>
+/bin/launchctl unload /Library/LaunchDaemons/org.jenkins-ci.plist</string>
+                <key>uninstall_method</key>
+                <string>uninstall_script</string>
+                <key>uninstall_script</key>
+                <string>#!/bin/bash
+				
+'/Library/Application Support/Jenkins/Uninstall.command'</string>
             </dict>
         </dict>
         <key>MinimumVersion</key>


### PR DESCRIPTION
Change the default uninstall_method from removepackages to uninstall_script 
https://wiki.jenkins.io/display/JENKINS/Thanks+for+using+OSX+Installer

I know the removepackages method leaves /Applications/Jenkins/ folder still intact, and perhaps some other remnants.