### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Understand/Understand.pkg.recipe
+++ b/Understand/Understand.pkg.recipe
@@ -27,7 +27,7 @@
                 <key>source_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Understand-%version%.%build%-MacOSX-x86.dmg/Understand.app</string>
                 <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Understand.app</string>
 	        </dict>
         </dict>
         <dict>
@@ -36,9 +36,9 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Understand.app/Contents/Info.plist</string>
                 <key>output_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Understand.app/Contents/Info.plist</string>
                 <key>plist_data</key>
                 <dict>
                     <key>CFBundleShortVersionString</key>
@@ -54,7 +54,7 @@
 			<key>Arguments</key>
 			<dict>
                 <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Understand.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 			</dict>
@@ -65,7 +65,7 @@
             <key>Arguments</key>
             <dict>
                 <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Understand.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>

--- a/jq/jq.pkg.recipe
+++ b/jq/jq.pkg.recipe
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
         <key>Description</key>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.