### PR TITLE
Use sparkle feed minimum_os_version

### DIFF
--- a/GPGTools/GPGSuite.munki.recipe
+++ b/GPGTools/GPGSuite.munki.recipe
@@ -30,8 +30,6 @@
                 <string>GPGSuite</string>
                 <key>name</key>
                 <string>%NAME%</string>
-			    <key>minimum_os_version</key>
-			    <string>10.12</string>
                 <key>blocking_applications</key>
                 <array>
                     <string>Mail</string>
@@ -43,6 +41,10 @@
                 <key>unattended_install</key>
                 <true/>
             </dict>
+            <key>pkginfo_keys_to_copy_from_sparkle_feed</key>
+            <array>
+              <string>minimum_os_version</string>
+            </array>
         </dict>
         <key>MinimumVersion</key>
         <string>0.2.0</string>


### PR DESCRIPTION
Use the min os requirement from the sparkle feed rather than a hardcoded value.