### PR TITLE
Update Enpass.munki.recipe

### DIFF
--- a/Enpass/Enpass.munki.recipe
+++ b/Enpass/Enpass.munki.recipe
@@ -49,6 +49,20 @@
                 <string>%pkg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
+                <key>pkginfo</key>
+                    <dict>
+                        <key>version</key>
+                        <string>%version%</string>
+                        <key>receipts</key>
+                        <array>
+                            <dict>
+                                <key>packageid</key>
+                                <string>in.sinew.Enpass-Desktop.App</string>
+                                <key>version</key>
+                                <string>%version%</string>
+                            </dict>
+                        </array>
+                    </dict>
             </dict>
         </dict>
     </array>


### PR DESCRIPTION
Fixes munki import to use version number instead of build number. Not sure if this is the best approach, but it seems to do the job. Also wasn't sure how (or if it possible) to get the `installed_size` set with the receipt, or if that even matters.