### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Jenkins/JenkinsURLProvider.py
+++ b/Jenkins/JenkinsURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 import subprocess
 import re

--- a/Jenkins/JenkinsURLProvider.py
+++ b/Jenkins/JenkinsURLProvider.py
@@ -16,10 +16,11 @@
 
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
-import subprocess
-import re
 
+import re
+import subprocess
+
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["JenkinsURLProvider"]
 

--- a/Node.js/NodeLatestURLProvider.py
+++ b/Node.js/NodeLatestURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from autopkglib import Processor
 
 

--- a/Node.js/NodeLatestURLProvider.py
+++ b/Node.js/NodeLatestURLProvider.py
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from autopkglib import Processor
 
+from autopkglib import Processor
 
 __all__ = ["NodeLatestURLProvider"]
 

--- a/SharedProcessors/EasyInstallPkgbuilder.py
+++ b/SharedProcessors/EasyInstallPkgbuilder.py
@@ -15,10 +15,11 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import shutil
-import tempfile
 import subprocess
+import tempfile
 
 from autopkglib import Processor, ProcessorError
 
@@ -70,16 +71,16 @@ class EasyInstallPkgbuilder(Processor):
         else:
              raise ProcessorError(
                  "Can't find binary %s: %s" % ('/usr/bin/pkgbuild', e.strerror))
-             
-             
-    def make_postinstall_script(self, scriptsdir, modulepath):    
+
+
+    def make_postinstall_script(self, scriptsdir, modulepath):
         modulename = os.path.basename(modulepath)
         shutil.copyfile(modulepath, os.path.join(scriptsdir, modulename))
         postinstall_path = os.path.join(scriptsdir, 'postinstall')
         with open(postinstall_path, 'w') as postinstall_script:
             postinstall_script.write("#!/bin/sh\n\nworking_dir=`/usr/bin/dirname \"${0}\"`\n/usr/bin/easy_install \"${working_dir}/%s\"\n" % modulename)
         os.chmod(postinstall_path, 0o755)
-    
+
 
     def main(self):
         python_pkg_path = self.env['python_pkg_path']
@@ -92,9 +93,8 @@ class EasyInstallPkgbuilder(Processor):
             self.pkgbuild(scriptsdir, identifier, version, pkgpath)
         finally:
             shutil.rmtree(scriptsdir)
- 
-                
+
+
 if __name__ == '__main__':
     processor = EasyInstallScriptCreator()
     processor.execute_shell()
-    

--- a/SharedProcessors/EasyInstallPkgbuilder.py
+++ b/SharedProcessors/EasyInstallPkgbuilder.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import os
 import shutil
 import tempfile
@@ -77,7 +78,7 @@ class EasyInstallPkgbuilder(Processor):
         postinstall_path = os.path.join(scriptsdir, 'postinstall')
         with open(postinstall_path, 'w') as postinstall_script:
             postinstall_script.write("#!/bin/sh\n\nworking_dir=`/usr/bin/dirname \"${0}\"`\n/usr/bin/easy_install \"${working_dir}/%s\"\n" % modulename)
-        os.chmod(postinstall_path, 0755)
+        os.chmod(postinstall_path, 0o755)
     
 
     def main(self):

--- a/SharedProcessors/GPGSignatureVerifier.py
+++ b/SharedProcessors/GPGSignatureVerifier.py
@@ -28,7 +28,7 @@ __all__ = ["GPGSignatureVerifier"]
 
 
 def check_for_goodsig(string):
-    return re.search("^\\[GNUPG:\\] GOODSIG ([0-9A-F]{8,})", string, re.M)
+    return re.search(r"^\\[GNUPG:\\] GOODSIG ([0-9A-F]{8,})", string, re.M)
 
 
 class GPGSignatureVerifier(Processor):

--- a/SharedProcessors/GPGSignatureVerifier.py
+++ b/SharedProcessors/GPGSignatureVerifier.py
@@ -17,13 +17,12 @@
 # work in progress, do not use
 
 from __future__ import absolute_import
+
 import os
-import shutil
-import subprocess
 import re
+import subprocess
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["GPGSignatureVerifier"]
 
@@ -59,7 +58,7 @@ class GPGSignatureVerifier(Processor):
             "description": "path to the distribution file."
         }
     }
-    
+
 
     def gpg_found(self):
         gpg_version_cmd = [self.env['gpg_path'], '--version']
@@ -72,8 +71,8 @@ class GPGSignatureVerifier(Processor):
             else:
                 raise ProcessorError("Finding gpg executable failed")
         return True
-    
-    
+
+
     def import_key(self):
         gpg_import_cmd = [self.env['gpg_path'], '--recv-keys', self.env['public_key_id']]
         try:
@@ -81,8 +80,8 @@ class GPGSignatureVerifier(Processor):
                 subprocess.call(gpg_import_cmd, stdout=devnull, stderr=devnull)
         except OSError as e:
             raise ProcessorError("Importing public key failed")
-        
-        
+
+
     def verify(self):
         gpg_verify_cmd = [self.env['gpg_path'], '--status-fd', '1', '--verify', self.env['signature_file'], self.env['distribution_file']]
         try:
@@ -94,7 +93,7 @@ class GPGSignatureVerifier(Processor):
         except:
             raise ProcessorError("Verifying signature failed")
 
-    
+
     def main(self):
         self.env['pathname'] = self.env['distribution_file']
         if self.gpg_found():
@@ -110,4 +109,3 @@ class GPGSignatureVerifier(Processor):
 if __name__ == '__main__':
     processor = GPGSignatureVerifier()
     processor.execute_shell()
-    

--- a/SharedProcessors/GPGSignatureVerifier.py
+++ b/SharedProcessors/GPGSignatureVerifier.py
@@ -16,6 +16,7 @@
 
 # work in progress, do not use
 
+from __future__ import absolute_import
 import os
 import shutil
 import subprocess

--- a/SharedProcessors/PkgsrcUpdater.py
+++ b/SharedProcessors/PkgsrcUpdater.py
@@ -16,6 +16,7 @@
 
 # work in progress, do not use
 
+from __future__ import absolute_import
 import os
 import shutil
 import subprocess

--- a/SharedProcessors/PkgsrcUpdater.py
+++ b/SharedProcessors/PkgsrcUpdater.py
@@ -17,13 +17,12 @@
 # work in progress, do not use
 
 from __future__ import absolute_import
+
 import os
-import shutil
-import subprocess
 import re
+import subprocess
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["PkgsrcUpdater"]
 
@@ -38,8 +37,8 @@ def get_rev(str):
         return result.group(1)
     else:
         return 0
-    
-    
+
+
 class PkgsrcUpdater(Processor):
     """Keeps a pkgsrc package up to date."""
     description = __doc__
@@ -61,7 +60,7 @@ class PkgsrcUpdater(Processor):
         }
     }
 
-    
+
     def get_installed_version(self, pkg):
         pkg_info_cmd = ['/opt/pkg/bin/pkg_info', '-E', pkg]
         p = subprocess.Popen(pkg_info_cmd,
@@ -69,31 +68,31 @@ class PkgsrcUpdater(Processor):
             stderr=subprocess.PIPE)
         (out, err) = p.communicate()
         return out.split('-')[1]
-    
-    
+
+
     def is_installed(self, pkg):
         pkg_info_cmd = ['/opt/pkg/bin/pkg_info', '-E', pkg]
         p = subprocess.Popen(pkg_info_cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
         return p.returncode == 0
-    
-    
+
+
     def run_update(self, pkg):
         pkgin_cmd = ['/opt/pkg/bin/pkgin', 'update', '-y', pkg]
         p = subprocess.Popen(pkgin_cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
         return p.communicate()
-    
+
     def run_install(self, pkg):
         pkgin_cmd = ['/opt/pkg/bin/pkgin', 'install', '-y', pkg]
         p = subprocess.Popen(pkgin_cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
         return p.communicate()
-        
-        
+
+
     def main(self):
         pkg = self.env['pkg']
         if self.is_installed(pkg):
@@ -111,9 +110,8 @@ class PkgsrcUpdater(Processor):
                     'pkg': pkg,
                 }
             }
- 
-                
+
+
 if __name__ == '__main__':
     processor = PkgsrcUpdater()
     processor.execute_shell()
-    

--- a/SharedProcessors/PyPIInfoProvider.py
+++ b/SharedProcessors/PyPIInfoProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import xmlrpclib
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/PyPIInfoProvider.py
+++ b/SharedProcessors/PyPIInfoProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import xmlrpclib
 
 from autopkglib import Processor, ProcessorError

--- a/SharedProcessors/SVNUpdater.py
+++ b/SharedProcessors/SVNUpdater.py
@@ -17,13 +17,13 @@
 # work in progress, do not use
 
 from __future__ import absolute_import
+
 import os
+import re
 import shutil
 import subprocess
-import re
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["SVNUpdater"]
 
@@ -131,4 +131,3 @@ class SVNUpdater(Processor):
 if __name__ == '__main__':
     processor = SVNUpdater()
     processor.execute_shell()
-    

--- a/SharedProcessors/SVNUpdater.py
+++ b/SharedProcessors/SVNUpdater.py
@@ -16,6 +16,7 @@
 
 # work in progress, do not use
 
+from __future__ import absolute_import
 import os
 import shutil
 import subprocess

--- a/SharedProcessors/VersionFixer.py
+++ b/SharedProcessors/VersionFixer.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 
 

--- a/SharedProcessors/VersionFixer.py
+++ b/SharedProcessors/VersionFixer.py
@@ -16,8 +16,8 @@
 
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
 
+from autopkglib import Processor, ProcessorError
 
 __all__ = ["VersionFixer"]
 
@@ -49,4 +49,3 @@ class VersionFixer(Processor):
 if __name__ == '__main__':
     processor = VersionFixer()
     processor.execute_shell()
-    


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.