### PR TITLE
Fix regression in re.search

### DIFF
--- a/SharedProcessors/GPGSignatureVerifier.py
+++ b/SharedProcessors/GPGSignatureVerifier.py
@@ -28,7 +28,7 @@ __all__ = ["GPGSignatureVerifier"]
 
 
 def check_for_goodsig(string):
-    return re.search(r"^\\[GNUPG:\\] GOODSIG ([0-9A-F]{8,})", string, re.M)
+    return re.search(r"^\[GNUPG:\] GOODSIG ([0-9A-F]{8,})", string, re.M)
 
 
 class GPGSignatureVerifier(Processor):


### PR DESCRIPTION
I think commit #118 broke the signature verifier?!

Example:
```
>>> print s

[GNUPG:] NEWSIG
gpg: Signature made Sat Aug 24 23:52:23 2019 CEST
gpg:                using RSA key 8C31E5A17DD5D932B448FE1DE8A664480D9E43F5
[GNUPG:] KEY_CONSIDERED 85E38F69046B44C1EC9FB07B76D78F0500D026C4 0
[GNUPG:] SIG_ID TmBpEFp3cLGQ6E6jgjCZhMy0m0U 2019-08-24 1566683543
[GNUPG:] KEY_CONSIDERED 85E38F69046B44C1EC9FB07B76D78F0500D026C4 0
gpg: checking the trustdb
gpg: no ultimately trusted keys found
[GNUPG:] GOODSIG E8A664480D9E43F5 GPGTools Team <team@gpgtools.org>
gpg: Good signature from "GPGTools Team <team@gpgtools.org>" [unknown]
gpg:                 aka "[jpeg image of size 5871]" [unknown]
[GNUPG:] VALIDSIG 8C31E5A17DD5D932B448FE1DE8A664480D9E43F5 2019-08-24 1566683543 0 4 0 1 8 00 85E38F69046B44C1EC9FB07B76D78F0500D026C4
[GNUPG:] KEY_CONSIDERED 85E38F69046B44C1EC9FB07B76D78F0500D026C4 0
[GNUPG:] KEY_CONSIDERED 85E38F69046B44C1EC9FB07B76D78F0500D026C4 0
[GNUPG:] TRUST_UNDEFINED

>>> import re
>>> re.search("^\\[GNUPG:\\] GOODSIG", s, re.M)           # before
<_sre.SRE_Match object at 0x10aa019f0>
>>> re.search(r"^\\[GNUPG:\\] GOODSIG", s, re.M)          # regression
>>> re.search(r"^\[GNUPG:\] GOODSIG", s, re.M)            # correct regex
<_sre.SRE_Match object at 0x10aa01a58>
```