### PR TITLE
Update JenkinsURLProvider with URLGetter, LooseVersion

### DIFF
--- a/Jenkins/Jenkins.download.recipe
+++ b/Jenkins/Jenkins.download.recipe
@@ -22,10 +22,8 @@
             <dict>
                 <key>Arguments</key>
                 <dict>
-                    <key>url</key>
-                    <string>http://mirrors.jenkins-ci.org/osx/latest</string>
                     <key>filename</key>
-                    <string>%NAME%.pkg</string>
+                    <string>%NAME%-%version%.pkg</string>
                 </dict>
                 <key>Processor</key>
                 <string>URLDownloader</string>


### PR DESCRIPTION
This PR updates JenkinsURLProvider to use the new [URLGetter superclass](https://github.com/autopkg/autopkg/wiki/Downloading-from-the-Internet-in-Custom-Processors), which adds compatibility with Python 3 and AutoPkg 2. It also uses LooseVersion to determine the latest available version of Jenkins, since their "latest" redirect appears to no longer work as of version 2.214.

AutoPkg verbose run logs:
https://gist.github.com/homebysix/a34f2f456277deb8ae5d61e165d22559