### PR TITLE
Update GPGSuite team name

### DIFF
--- a/GPGTools/GPGSuite.download.recipe
+++ b/GPGTools/GPGSuite.download.recipe
@@ -48,7 +48,7 @@
                 <dict>
                     <key>expected_authority_names</key>
                     <array>
-                        <string>Developer ID Installer: Lukas Pitschl (PKV8ZPD836)</string>
+                        <string>Developer ID Installer: GPGTools GmbH (PKV8ZPD836)</string>
                         <string>Developer ID Certification Authority</string>
                         <string>Apple Root CA</string>
                     </array>


### PR DESCRIPTION
GPGSuite recently changed their developer team name leading the download recipe to fail. 

 Mon Jun  8 16:27:28 2020 b'' autopkg_tools: b'CodeSignatureVerifier: Signature is valid'
 Mon Jun  8 16:27:28 2020 b'' autopkg_tools: b'CodeSignatureVerifier: Mismatch in authority names'
 Mon Jun  8 16:27:28 2020 b'' autopkg_tools: b'CodeSignatureVerifier: Expected: Developer ID Installer: Lukas Pitschl (PKV8ZPD836) -> Developer ID Certification Authority -> Apple Root CA'
 Mon Jun  8 16:27:28 2020 b'' autopkg_tools: b'CodeSignatureVerifier: Found:    Developer ID Installer: GPGTools GmbH (PKV8ZPD836) -> Developer ID Certification Authority -> Apple Root CA'