### PR TITLE
URL Change

### DIFF
--- a/ownCloud/ownCloudDesktopClient.download.recipe
+++ b/ownCloud/ownCloudDesktopClient.download.recipe
@@ -21,7 +21,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>url</key>
-                    <string>https://owncloud.org/download</string>
+                    <string>https://owncloud.com/desktop-app/</string>
                     <key>re_pattern</key>
                     <string>href=\"(?P&lt;url&gt;https://download.owncloud.com/desktop/stable/ownCloud-(?P&lt;version&gt;[0-9\.]+).pkg)\"</string>
                 </dict>


### PR DESCRIPTION
The old URL (https://owncloud.org/download) now 404's and it looks like this page has been moved to https://owncloud.com/desktop-app/