### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/Understand/Understand.download.recipe
+++ b/Understand/Understand.download.recipe
@@ -66,7 +66,7 @@
             <dict>
                 <key>input_path</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/Understand-%version%.%build%-MacOSX-x86.dmg/Understand.app</string>
-                <key>requirements</key>
+                <key>requirement</key>
                 <string>identifier "com.scitools.Understand" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = CNU9P2K643</string>
             </dict>
         </dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.