### PR TITLE
Add architecture support to MySQL Community Server

### DIFF
--- a/MySQL/MySQLCommunityServer.download.recipe
+++ b/MySQL/MySQLCommunityServer.download.recipe
@@ -12,6 +12,9 @@
             <string>MySQLCommunityServer</string>
             <key>RELEASE</key>
             <string>8.0</string>
+            <key>ARCHITECTURE</key>
+            <!-- x86_64 or arm64 -->
+            <string>x86_64</string>
             <key>USER_AGENT</key>
             <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3) AppleWebKit/536.28.10 (KHTML, like Gecko) Version/6.0.3 Safari/536.28.10</string>
         </dict>
@@ -27,7 +30,7 @@
                     <key>url</key>
                     <string>https://dev.mysql.com/downloads/mysql/%RELEASE%.html</string>
                     <key>re_pattern</key>
-                    <string>\((?P&lt;rel_url&gt;mysql-(?P&lt;version&gt;[0-9\.]+)-.*?dmg)\)</string>
+                    <string>\((?P&lt;rel_url&gt;mysql-(?P&lt;version&gt;[0-9\.]+)-.*-).*?dmg\)</string>
                     <key>request_headers</key>
                     <dict>
                         <key>user-agent</key>
@@ -39,7 +42,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>url</key>
-                    <string>https://dev.mysql.com/get/Downloads/MySQL-%RELEASE%/%rel_url%</string>
+                    <string>https://dev.mysql.com/get/Downloads/MySQL-%RELEASE%/%rel_url%%ARCHITECTURE%.dmg</string>
                     <key>filename</key>
                     <string>%NAME%.dmg</string>
                 </dict>

--- a/MySQL/MySQLCommunityServer.munki.recipe
+++ b/MySQL/MySQLCommunityServer.munki.recipe
@@ -32,6 +32,10 @@
                 <string>MySQL Community Server</string>
                 <key>name</key>
                 <string>%NAME%</string>
+                <key>supported_architectures</key>
+                <array>
+                    <string>%ARCHITECTURE%</string>
+                </array>
                 <key>unattended_install</key>
                 <false/>
             </dict>


### PR DESCRIPTION
Hi Gerard,

Oracle now offers two subversions of their .dmg. One for regular Intel Macs and one for ARM Macs.
By default the recipe now picks up ARM. This does not run on Intel Macs. That's why I'm adding architecture support.

I'm not entirely sure I should add the architecture to .munki.recipe too because that will restrict people from running x86_64 version of this app on arm64 laptops while that would work. Not the other way around though, for sure!
- please adjust my PR/MR if you want to remove that.

With regards to .download.recipe.
I've included some cut up output of running .download.recipe for both architectures.

**Test x86_64**
'ARCHITECTURE': 'x86_64'
'RELEASE': '8.0'
'Output': {'match': 'mysql-8.0.26-macos11-',
            'rel_url': 'mysql-8.0.26-macos11-',
            'version': '8.0.26'}
'url': 'https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.26-macos11-x86_64.dmg'
```
**Test arm64**
```
'ARCHITECTURE': 'arm64'
'RELEASE': '8.0'
'Output': {'match': 'mysql-8.0.26-macos11-',
            'rel_url': 'mysql-8.0.26-macos11-',
            'version': '8.0.26'}
'url': 'https://dev.mysql.com/get/Downloads/MySQL-8.0/mysql-8.0.26-macos11-arm64.dmg'
```
