### PR TITLE
Update SequelAce.munki.recipe

### DIFF
--- a/SequelAce/SequelAce.munki.recipe
+++ b/SequelAce/SequelAce.munki.recipe
@@ -37,16 +37,27 @@
     <key>MinimumVersion</key>
     <string>0.4.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.gerardkok.pkg.SequelAce</string>
+    <string>com.github.gerardkok.download.SequelAce</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DmgCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/unpacked/</string>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>MunkiImporter</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%dmg_path%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
              </dict>


### PR DESCRIPTION
• changes parent to .download
• creates an installs array of the .app on disk

```
Processing /Users/ben/Git/other-recipes/gerardkok-recipes/SequelAce/SequelAce.munki.recipe...
WARNING: /Users/ben/Git/other-recipes/gerardkok-recipes/SequelAce/SequelAce.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'GITHUB_TOKEN_PATH': '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',
           'asset_regex': 'Sequel-Ace-[0-9\\.]+\\.zip',
           'github_repo': 'Sequel-Ace/Sequel-Ace'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: Matched regex 'Sequel-Ace-[0-9\.]+\.zip' among asset(s): Sequel-Ace-3.4.0.zip
GitHubReleasesInfoProvider: Selected asset 'Sequel-Ace-3.4.0.zip' from release '3.4.0 (3038)'
{'Output': {'release_notes': '- Fixed a bug in which the tab titles sometimes '
                             'got out of sync with the actual contents of the '
                             'tabs\r\n'
                             '- Support for inserting new rows in tables that '
                             'have generated columns\r\n'
                             '- In the Structure tab, Generated columns are '
                             'now indicated as VIRTUAL GENERATED or STORED '
                             'GENERATED\r\n'
                             '- Fixed buggy behavior when trying to edit a '
                             'generated column, or when using pre-query '
                             'warnings\r\n'
                             '- Fixed warnings about character counts when '
                             'attempting to insert multi-byte strings',
            'url': 'https://github.com/Sequel-Ace/Sequel-Ace/releases/download/production/3.4.0-3038/Sequel-Ace-3.4.0.zip',
            'version': 'production/3.4.0-3038'}}
URLDownloader
{'Input': {'filename': 'SequelAce.zip',
           'url': 'https://github.com/Sequel-Ace/Sequel-Ace/releases/download/production/3.4.0-3038/Sequel-Ace-3.4.0.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/downloads/SequelAce.zip
{'Output': {'pathname': '/Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/downloads/SequelAce.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '/Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/downloads/SequelAce.zip',
           'destination_path': '/Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/unpacked',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename SequelAce.zip
Unarchiver: Unarchived /Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/downloads/SequelAce.zip to /Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/unpacked
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/unpacked/Sequel '
                         'Ace.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.sequel-ace.sequel-ace" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = NKQ4HJ66PX)',
           'strict_verification': True}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/unpacked/Sequel Ace.app: valid on disk
CodeSignatureVerifier: /Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/unpacked/Sequel Ace.app: satisfies its Designated Requirement
CodeSignatureVerifier: /Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/unpacked/Sequel Ace.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
DmgCreator
{'Input': {'dmg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/SequelAce.dmg',
           'dmg_root': '/Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/unpacked/'}}
DmgCreator: Created dmg from /Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/unpacked/ at /Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/SequelAce.dmg
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '/Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/SequelAce.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Developer',
                       'description': 'Sequel Ace is the "sequel" to longtime '
                                      'macOS tool Sequel Pro. Sequel Ace is a '
                                      'fast, easy-to-use Mac database '
                                      'management application for working with '
                                      'MySQL & MariaDB databases.',
                       'developer': 'Moballo',
                       'display_name': 'Sequel Ace',
                       'name': 'SequelAce',
                       'unattended_install': True},
           'repo_subdirectory': 'apps'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/SequelAce-3.4.0__2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/SequelAce-3.4.0.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'SequelAce',
                                                       'pkg_repo_path': 'apps/SequelAce-3.4.0.dmg',
                                                       'pkginfo_path': 'apps/SequelAce-3.4.0__2.plist',
                                                       'version': '3.4.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'ben',
                                         'creation_date': datetime.datetime(2021, 8, 3, 12, 2, 1),
                                         'munki_version': '5.5.0.4360',
                                         'os_version': '10.15.7'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Developer',
                           'description': 'Sequel Ace is the "sequel" to '
                                          'longtime macOS tool Sequel Pro. '
                                          'Sequel Ace is a fast, easy-to-use '
                                          'Mac database management application '
                                          'for working with MySQL & MariaDB '
                                          'databases.',
                           'developer': 'Moballo',
                           'display_name': 'Sequel Ace',
                           'installer_item_hash': '45c1c78cc7d56fc25b8e729e3ad00ed76e350c1e5c72ef14e4371dbd58ebd4a3',
                           'installer_item_location': 'apps/SequelAce-3.4.0.dmg',
                           'installer_item_size': 19507,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.sequel-ace.sequel-ace',
                                         'CFBundleName': 'Sequel Ace',
                                         'CFBundleShortVersionString': '3.4.0',
                                         'CFBundleVersion': '3038',
                                         'minosversion': '10.12',
                                         'path': '/Applications/Sequel Ace.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Sequel Ace.app'}],
                           'minimum_os_version': '10.12',
                           'name': 'SequelAce',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '3.4.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/SequelAce-3.4.0.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/SequelAce-3.4.0__2.plist'}}
Receipt written to /Users/ben/Library/AutoPkg/Cache/com.github.gerardkok.munki.SequelAce/receipts/SequelAce.munki-receipt-20210803-130201.plist

The following new items were imported into Munki:
    Name       Version  Catalogs  Pkginfo Path                   Pkg Repo Path             Icon Repo Path
    ----       -------  --------  ------------                   -------------             --------------
    SequelAce  3.4.0    testing   apps/SequelAce-3.4.0__2.plist  apps/SequelAce-3.4.0.dmg
```