### PR TITLE
Versions.app: Sparkle feed URL updated

### DIFF
--- a/Versions/Versions.download.recipe
+++ b/Versions/Versions.download.recipe
@@ -11,7 +11,7 @@
             <key>NAME</key>
             <string>Versions</string>
             <key>SPARKLE_FEED_URL</key>
-            <string>https://updates.blackpixel.com/updates?app=vs</string>
+            <string>https://updates.versionsapp.com/v2/prod/appcast</string>
         </dict>
         <key>MinimumVersion</key>
         <string>0.3.1</string>


### PR DESCRIPTION
The Sparkle feed URL has changed for Versions.app and the old URL does not seem to receive updates any more.