### PR TITLE
Update GPGSuiteUniversal.munki.recipe

### DIFF
--- a/GPGTools/GPGSuiteUniversal.munki.recipe
+++ b/GPGTools/GPGSuiteUniversal.munki.recipe
@@ -30,8 +30,6 @@
                 <string>GPGSuite</string>
                 <key>name</key>
                 <string>%NAME%</string>
-			    <key>minimum_os_version</key>
-			    <string>10.12</string>
                 <key>blocking_applications</key>
                 <array>
                     <string>Mail</string>
@@ -86,6 +84,19 @@
             <dict>
                 <key>Arguments</key>
                 <dict>
+                    <key>re_pattern</key>
+                    <string>&lt;sparkle:minimumSystemVersion&gt;([0-9]*\.[0-9]+)&lt;/sparkle:minimumSystemVersion&gt;</string>
+                    <key>result_output_var_name</key>
+                    <string>min_os_ver</string>
+                    <key>url</key>
+                    <string>https://gpgtools.org/releases/gpgsuite/appcast.xml</string>
+                </dict>
+                <key>Processor</key>
+                <string>URLTextSearcher</string>
+            </dict>
+            <dict>
+                <key>Arguments</key>
+                <dict>
                     <key>faux_root</key>
                     <string>%RECIPE_CACHE_DIR%/unpack</string>
                     <key>installs_item_paths</key>
@@ -120,6 +131,8 @@
                     <dict>
                         <key>version</key>
                         <string>%version%</string>
+                        <key>minimum_os_version</key>
+                        <string>%min_os_ver%</string>
                     </dict>
                 </dict>
                 <key>Processor</key>


### PR DESCRIPTION
Hi, @gerardkok 

I've noticed that GPGSuites Minimum OS Version is published on the sparkle feed, 10.15 at time of writing. 

```
curl https://gpgtools.org/releases/gpgsuite/appcast.xml
<?xml version="1.0" encoding="utf-8"?>
<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
	<channel>
		<title>GPG Suite releases</title>
		<link>https://gpgtools.com/releases/gpgsuite/appcast.xml</link>
		<description>Releases of GPG Suite</description>
		<language>en</language>
		<item>
			<title>GPG Suite 2022.2</title>
			<sparkle:releaseNotesLink>https://gpgtools.com/releases/gpgsuite/2022.2/release-notes.html</sparkle:releaseNotesLink>
			<pubDate>Mon, 24 Oct 2022 15:21:56 +0200</pubDate>
			<sparkle:minimumSystemVersion>10.15</sparkle:minimumSystemVersion>
			<enclosure url="https://releases.gpgtools.org/GPG_Suite-2022.2.dmg" sparkle:version="150" sparkle:shortVersionString="2022.2" type="application/octet-stream"/>
		</item>
		</channel>
</rss>
```

This PR adds in `URLTextSearcher` to grab the minimum os version from the sparkle feed and add it to the pkginfo.

Output from a successful -v run 

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/gerardkok-recipes/GPGTools/GPGSuiteUniversal.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/gerardkok-recipes/GPGTools/GPGSuiteUniversal.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/gerardkok-recipes/GPGTools/GPGSuiteUniversal.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
SparkleUpdateInfoProvider: Items in feed: 1
SparkleUpdateInfoProvider: Items in default channel: 1
SparkleUpdateInfoProvider: Version retrieved from appcast: 150
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 2022.2
SparkleUpdateInfoProvider: Found URL https://releases.gpgtools.org/GPG_Suite-2022.2.dmg
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul/Library/AutoPkg/Cache/com.github.gerardkok.munki.GPGSuiteUniversal/downloads/GPGSuite.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.gerardkok.munki.GPGSuiteUniversal/downloads/GPGSuite.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Install.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2022-10-24 12:30:06 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: GPGTools GmbH (PKV8ZPD836)
CodeSignatureVerifier:        Expires: 2025-01-24 09:37:24 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            9F 71 DA 6D F8 CD F7 CC BA 64 A3 72 AA 97 09 15 7B 75 3E E2 B6 6A 
CodeSignatureVerifier:            AB 72 B1 15 27 7C 17 DE 48 E2
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.gerardkok.munki.GPGSuiteUniversal/downloads/GPGSuite.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.HCFgyb/Install.pkg to /Users/paul/Library/AutoPkg/Cache/com.github.gerardkok.munki.GPGSuiteUniversal/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul/Library/AutoPkg/Cache/com.github.gerardkok.munki.GPGSuiteUniversal/unpack/Updater_Core.pkg/Payload to /Users/paul/Library/AutoPkg/Cache/com.github.gerardkok.munki.GPGSuiteUniversal/unpack
Copier
Copier: Copied /Users/paul/Library/AutoPkg/Cache/com.github.gerardkok.munki.GPGSuiteUniversal/unpack/private/tmp/org.gpgtools/updater_install to /Users/paul/Library/AutoPkg/Cache/com.github.gerardkok.munki.GPGSuiteUniversal/unpack/Library/Application Support/GPGTools
URLTextSearcher
URLTextSearcher: Found matching text (min_os_ver): 10.15
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Library/Application Support/GPGTools/GPGSuite_Updater.app
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'org.gpgtools.updater', 'CFBundleName': 'GPGSuite_Updater', 'CFBundleShortVersionString': '2022.2', 'CFBundleVersion': '150', 'minosversion': '10.9', 'path': '/Library/Application Support/GPGTools/GPGSuite_Updater.app', 'type': 'application', 'version_comparison_key': 'CFBundleVersion'}]} into pkginfo
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '2022.2', 'minimum_os_version': '10.15'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/GPGSuite-2022.2__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/GPGSuite-2022.2__1.dmg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.gerardkok.munki.GPGSuiteUniversal/receipts/GPGSuiteUniversal.munki-receipt-20230106-163653.plist

The following new items were imported into Munki:
    Name      Version  Catalogs  Pkginfo Path                   Pkg Repo Path                Icon Repo Path  
    ----      -------  --------  ------------                   -------------                --------------  
    GPGSuite  2022.2   testing   apps/GPGSuite-2022.2__1.plist  apps/GPGSuite-2022.2__1.dmg
```