### PR TITLE
Skip building jq package when there is no change

### DIFF
--- a/jq/jq.pkg.recipe
+++ b/jq/jq.pkg.recipe
@@ -12,6 +12,8 @@
             <string>jq</string>
             <key>PKG_ID</key>
             <string>com.github.gerardkok.pkg.jq</string>
+            <key>BUILD_PREDICATE</key>
+            <string>download_changed == False</string>
         </dict>
         <key>MinimumVersion</key>
         <string>0.2.0</string>
@@ -19,6 +21,15 @@
         <string>com.github.gerardkok.verify.jq</string>
         <key>Process</key>
         <array>
+            <dict>
+                <key>Processor</key>
+                <string>StopProcessingIf</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>predicate</key>
+                    <string>%BUILD_PREDICATE%</string>
+                </dict>
+            </dict>
             <dict>
                 <key>Processor</key>
                 <string>PkgRootCreator</string>


### PR DESCRIPTION
Currently the jq PKG is rebuilt on every run of autopkg. This can be avoided by setting a predicate to stop the build if the download step does not download a new binary. 

The original behavior could be maintained if the BUILD_PREDICATE input variable is set to FALSEPREDICATE  in an override. This would always evaluate to False and thereby bypass the StopProcessingIf processor.