### PR TITLE
feat: parameterize search URL and pattern for 1Password CLI

### DIFF
--- a/1Password/1PasswordCLI.download.recipe
+++ b/1Password/1PasswordCLI.download.recipe
@@ -12,6 +12,10 @@
             <string>1PasswordCLI</string>
             <key>PKG_ID</key>
             <string>com.1password.op</string>
+            <key>SEARCH_URL</key>
+            <string>https://app-updates.agilebits.com/product_history/CLI</string>
+            <key>SEARCH_PATTERN</key>
+            <string>href=\"(?P&lt;url&gt;https://cache.agilebits.com/dist/1P/op/pkg/v[0-9\.]+/op_darwin_amd64_v(?P&lt;version&gt;[0-9\.]+).pkg)\"</string>
         </dict>
         <key>MinimumVersion</key>
         <string>0.2.0</string>
@@ -23,9 +27,9 @@
                 <key>Arguments</key>
                 <dict>
                     <key>url</key>
-                    <string>https://app-updates.agilebits.com/product_history/CLI</string>
+                    <string>%SEARCH_URL%</string>
                     <key>re_pattern</key>
-                    <string>href=\"(?P&lt;url&gt;https://cache.agilebits.com/dist/1P/op/pkg/v[0-9\.]+/op_darwin_amd64_v(?P&lt;version&gt;[0-9\.]+).pkg)\"</string>
+                    <string>%SEARCH_PATTERN%</string>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
This PR parameterizes the search URL and regular expression pattern for the 1Password CLI download. This allows users to specify alternate URLs and patterns to download the v2 beta CLI instead of only the v1 release.

For example, the following Input keys will download the latest v2 CLI:

- `SEARCH_URL` = `https://app-updates.agilebits.com/product_history/CLI2`
- `SEARCH_PATTERN` = `href=\"(?P&lt;url&gt;https://cache.agilebits.com/dist/1P/op2/pkg/v[0-9\.]+/op_apple_universal_v(?P&lt;version&gt;[0-9\.]+).pkg)\"`

Parameterizing those Inputs with the current values used as processor arguments ensures existing workflows and child recipes do not break. There will be no changes for existing users, and they will continue to download the v1 CLI tool. Only those manually providing alternate URLs and patterns will see a difference.