### PR TITLE
Fix for enpass.download-recipe

### DIFF
--- a/Enpass/Enpass.download.recipe
+++ b/Enpass/Enpass.download.recipe
@@ -15,26 +15,17 @@
 	<string>0.3.1</string>
 	<key>Process</key>
 	<array>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;https:\/\/dl\.enpass\.io\/stable\/mac\/package\/.*?Enpass\.pkg?)</string>
-				<key>url</key>
-				<string>https://www.enpass.io/downloads/</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>filename</key>
-				<string>Enpass.pkg</string>
-			</dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
-		</dict>
+                <dict>
+                        <key>Arguments</key>
+                        <dict>
+                                <key>url</key>
+                                <string>https://www.enpass.io/download/macos/website/stable</string>
+                                <key>filename</key>
+                                <string>Enpass.pkg</string>
+                        </dict>
+                        <key>Processor</key>
+                        <string>URLDownloader</string>
+                </dict>
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>


### PR DESCRIPTION
Dropped URLTextSearcher and modified URLDownloader

Fixes #246 