### PR TITLE
Deprecate 1Password CLI recipes

### DIFF
--- a/1Password/1PasswordCLI.download.recipe
+++ b/1Password/1PasswordCLI.download.recipe
@@ -23,6 +23,15 @@
         <array>
             <dict>
                 <key>Processor</key>
+                <string>DeprecationWarning</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>warning_message</key>
+                    <string>Consider switching to the 1Password_CLI recipes in the apettinen-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
                 <string>URLTextSearcher</string>
                 <key>Arguments</key>
                 <dict>


### PR DESCRIPTION
The 1Password CLI recipes in this repo are downloading version 1 of the tool, and are not functionally different than the recipes in apettinen-recipes that download the newer version 2 of the tool.

This PR deprecates the 1Password CLI recipes and points users to their equivalents in the apettinen-recipes repo.
