### PR TITLE
Fix Yubikey Authenticator recipes

### DIFF
--- a/YubiKey/YubiKeyAuthenticator.download.recipe
+++ b/YubiKey/YubiKeyAuthenticator.download.recipe
@@ -21,18 +21,20 @@
                 <key>Arguments</key>
                 <dict>
                     <key>url</key>
-                    <string>https://developers.yubico.com/yubioath-desktop/Releases/</string>
+                    <string>https://developers.yubico.com/yubioath-flutter/Releases/</string>
                     <key>re_pattern</key>
-                    <string>href=\"(?P&lt;relative_download_url&gt;yubioath-desktop-(?P&lt;version&gt;[0-9\.]+)-mac\.pkg)\"</string>
+                    <string>href="yubico-authenticator-([\d\.]+)-mac.dmg"</string>
+                    <key>result_output_var_name</key>
+                    <string>version</string>
                 </dict>
             </dict>
             <dict>
                 <key>Arguments</key>
                 <dict>
                     <key>url</key>
-                    <string>https://developers.yubico.com/yubioath-desktop/Releases/%relative_download_url%</string>
+                    <string>https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-%version%-mac.dmg</string>
                     <key>filename</key>
-                    <string>%NAME%.pkg</string>
+                    <string>%NAME%-%version%.dmg</string>
                 </dict>
                 <key>Processor</key>
                 <string>URLDownloader</string>
@@ -47,13 +49,9 @@
                 <key>Arguments</key>
                 <dict>
                     <key>input_path</key>
-                    <string>%pathname%</string>
-                    <key>expected_authority_names</key>
-                    <array>
-                        <string>Developer ID Installer: Yubico Limited (LQA3CS5MM7)</string>
-                        <string>Developer ID Certification Authority</string>
-                        <string>Apple Root CA</string>
-                    </array>
+                    <string>%pathname%/Yubico Authenticator.app</string>
+                    <key>requirement</key>
+                    <string>identifier "com.yubico.yubioath" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = LQA3CS5MM7</string>
                 </dict>
             </dict>
         </array>


### PR DESCRIPTION
This PR adjusts the Yubikey Authenticator recipes to accept the new dmg download format.

Verbose recipe run output:

```
% autopkg run -vvq 'YubiKey/YubiKeyAuthenticator.download.recipe'
Processing YubiKey/YubiKeyAuthenticator.download.recipe...
WARNING: YubiKey/YubiKeyAuthenticator.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="yubico-authenticator-([\\d\\.]+)-mac.dmg"',
           'result_output_var_name': 'version',
           'url': 'https://developers.yubico.com/yubioath-flutter/Releases/'}}
URLTextSearcher: Found matching text (version): 7.1.1
{'Output': {'version': '7.1.1'}}
URLDownloader
{'Input': {'filename': 'YubiKeyAuthenticator-7.1.1.dmg',
           'url': 'https://developers.yubico.com/yubioath-flutter/Releases/yubico-authenticator-7.1.1-mac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 30 Oct 2024 10:05:38 GMT
URLDownloader: Storing new ETag header: "238853c32d61e73fdf8e6de65b129cef"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gerardkok.download.YubiKeyAuthenticator/downloads/YubiKeyAuthenticator-7.1.1.dmg
{'Output': {'download_changed': True,
            'etag': '"238853c32d61e73fdf8e6de65b129cef"',
            'last_modified': 'Wed, 30 Oct 2024 10:05:38 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.YubiKeyAuthenticator/downloads/YubiKeyAuthenticator-7.1.1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.YubiKeyAuthenticator/downloads/YubiKeyAuthenticator-7.1.1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.YubiKeyAuthenticator/downloads/YubiKeyAuthenticator-7.1.1.dmg/Yubico '
                         'Authenticator.app',
           'requirement': 'identifier "com.yubico.yubioath" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'LQA3CS5MM7'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.gerardkok.download.YubiKeyAuthenticator/downloads/YubiKeyAuthenticator-7.1.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.wCtguJ/Yubico Authenticator.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.wCtguJ/Yubico Authenticator.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.wCtguJ/Yubico Authenticator.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gerardkok.download.YubiKeyAuthenticator/receipts/YubiKeyAuthenticator.download-receipt-20241225-202038.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.gerardkok.download.YubiKeyAuthenticator/downloads/YubiKeyAuthenticator-7.1.1.dmg
```
