### PR TITLE
Fix Understand recipes

### DIFF
--- a/Understand/Understand.download.recipe
+++ b/Understand/Understand.download.recipe
@@ -16,30 +16,25 @@
     <key>Process</key>
     <array>
         <dict>
-            <key>Processor</key>
-            <string>URLTextSearcher</string>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>https://scitools.com/download/all-builds/</string>
                 <key>re_pattern</key>
-                <string>&lt;strong&gt;Understand (?P&lt;version&gt;[0-9\.]+)\((?P&lt;build&gt;[0-9\.]+)</string>
-                <key>request_headers</key>
-                <dict>
-                    <key>user-agent</key>
-                    <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.170 Safari/537.36</string>
-                </dict>
+                <string>(https://latest.scitools.com/Understand/Understand-(?P&lt;version&gt;[\d\.]+)-macOS-Universal.dmg)</string>
+                <key>result_output_var_name</key>
+                <string>url</string>
+                <key>url</key>
+                <string>https://licensing.scitools.com/download/thanks/macOS-Universal.dmg</string>
             </dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
         </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>http://builds.scitools.com/all_builds/b%build%/Understand/understand-macosx.zip</string>
                 <key>filename</key>
-                <string>%NAME%.zip</string>
+                <string>%NAME%-%version%.dmg</string>
             </dict>
         </dict>
         <dict>
@@ -48,24 +43,11 @@
         </dict>
         <dict>
             <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
             <string>CodeSignatureVerifier</string>
             <key>Arguments</key>
             <dict>
                 <key>input_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Understand-%version%.%build%-MacOSX-x86.dmg/Understand.app</string>
+                <string>%pathname%/Understand.app</string>
                 <key>requirement</key>
                 <string>identifier "com.scitools.Understand" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = CNU9P2K643</string>
             </dict>

--- a/Understand/Understand.munki.recipe
+++ b/Understand/Understand.munki.recipe
@@ -37,7 +37,7 @@
     <key>MinimumVersion</key>
     <string>0.4.0</string>
     <key>ParentRecipe</key>
-    <string>com.github.gerardkok.pkg.Understand</string>
+    <string>com.github.gerardkok.download.Understand</string>
     <key>Process</key>
     <array>
         <dict>
@@ -46,7 +46,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
              </dict>

--- a/Understand/Understand.pkg.recipe
+++ b/Understand/Understand.pkg.recipe
@@ -14,71 +14,20 @@
         <string>com.scitools.Understand</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.4.0</string>
+    <string>1.0</string>
     <key>ParentRecipe</key>
     <string>com.github.gerardkok.download.Understand</string>
     <key>Process</key>
     <array>
+    <dict>
+        <key>Processor</key>
+        <string>AppPkgCreator</string>
+        <key>Arguments</key>
         <dict>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Understand-%version%.%build%-MacOSX-x86.dmg/Understand.app</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Understand.app</string>
-	        </dict>
+            <key>app_path</key>
+            <string>%pathname%/Understand.app</string>
         </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PlistEditor</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Understand.app/Contents/Info.plist</string>
-                <key>output_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Understand.app/Contents/Info.plist</string>
-                <key>plist_data</key>
-                <dict>
-                    <key>CFBundleShortVersionString</key>
-                    <string>%version%.%build%</string>
-                    <key>CFBundleGetInfoString</key>
-                    <string>%version%.%build%, Copyright © 1990-2016 Scientific Toolworks Inc.</string>
-                </dict>
-	        </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-			<string>DmgCreator</string>
-			<key>Arguments</key>
-			<dict>
-                <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Understand.app</string>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-			</dict>
-		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>Versioner</string>
-            <key>Arguments</key>
-            <dict>
-                <key>input_plist_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Understand.app/Contents/Info.plist</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
-            <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                </array>
-            </dict>
-        </dict>
+    </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR adjusts the Understand recipes to leverage the new Universal dmg download.

Verbose recipe run output for the download, pkg, and munki recipes:

```
% autopkg run -vvq Understand/Understand.*.recipe
Processing Understand/Understand.download.recipe...
WARNING: Understand/Understand.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(https://latest.scitools.com/Understand/Understand-(?P<version>[\\d\\.]+)-macOS-Universal.dmg)',
           'result_output_var_name': 'url',
           'url': 'https://licensing.scitools.com/download/thanks/macOS-Universal.dmg'}}
URLTextSearcher: Found matching text (version): 7.0.1213
URLTextSearcher: Found matching text (url): https://latest.scitools.com/Understand/Understand-7.0.1213-macOS-Universal.dmg
{'Output': {'url': 'https://latest.scitools.com/Understand/Understand-7.0.1213-macOS-Universal.dmg',
            'version': '7.0.1213'}}
URLDownloader
{'Input': {'filename': 'Understand-7.0.1213.dmg',
           'url': 'https://latest.scitools.com/Understand/Understand-7.0.1213-macOS-Universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 18 Dec 2024 23:34:29 GMT
URLDownloader: Storing new ETag header: "bebabb79c80956a2932ba77fd12e279e-86"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gerardkok.download.Understand/downloads/Understand-7.0.1213.dmg
{'Output': {'download_changed': True,
            'etag': '"bebabb79c80956a2932ba77fd12e279e-86"',
            'last_modified': 'Wed, 18 Dec 2024 23:34:29 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.Understand/downloads/Understand-7.0.1213.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.Understand/downloads/Understand-7.0.1213.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.Understand/downloads/Understand-7.0.1213.dmg/Understand.app',
           'requirement': 'identifier "com.scitools.Understand" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'CNU9P2K643'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.gerardkok.download.Understand/downloads/Understand-7.0.1213.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.tf5dPF/Understand.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.tf5dPF/Understand.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.tf5dPF/Understand.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gerardkok.download.Understand/receipts/Understand.download-receipt-20241225-201155.plist
Processing Understand/Understand.munki.recipe...
WARNING: Understand/Understand.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(https://latest.scitools.com/Understand/Understand-(?P<version>[\\d\\.]+)-macOS-Universal.dmg)',
           'result_output_var_name': 'url',
           'url': 'https://licensing.scitools.com/download/thanks/macOS-Universal.dmg'}}
URLTextSearcher: Found matching text (version): 7.0.1213
URLTextSearcher: Found matching text (url): https://latest.scitools.com/Understand/Understand-7.0.1213-macOS-Universal.dmg
{'Output': {'url': 'https://latest.scitools.com/Understand/Understand-7.0.1213-macOS-Universal.dmg',
            'version': '7.0.1213'}}
URLDownloader
{'Input': {'filename': 'Understand-7.0.1213.dmg',
           'url': 'https://latest.scitools.com/Understand/Understand-7.0.1213-macOS-Universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 18 Dec 2024 23:34:29 GMT
URLDownloader: Storing new ETag header: "bebabb79c80956a2932ba77fd12e279e-86"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gerardkok.munki.Understand/downloads/Understand-7.0.1213.dmg
{'Output': {'download_changed': True,
            'etag': '"bebabb79c80956a2932ba77fd12e279e-86"',
            'last_modified': 'Wed, 18 Dec 2024 23:34:29 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gerardkok.munki.Understand/downloads/Understand-7.0.1213.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.munki.Understand/downloads/Understand-7.0.1213.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.munki.Understand/downloads/Understand-7.0.1213.dmg/Understand.app',
           'requirement': 'identifier "com.scitools.Understand" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'CNU9P2K643'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.gerardkok.munki.Understand/downloads/Understand-7.0.1213.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.EL8bwe/Understand.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.EL8bwe/Understand.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.EL8bwe/Understand.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.munki.Understand/downloads/Understand-7.0.1213.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'category': 'Science',
                       'description': 'Understand provides you with pertinent '
                                      'information regarding your code.',
                       'developer': 'Scientific Toolworks',
                       'display_name': 'Understand',
                       'name': 'Understand',
                       'unattended_install': True},
           'repo_subdirectory': 'apps'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Understand-7.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Understand-7.0.1213-7.0.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Understand',
                                                       'pkg_repo_path': 'apps/Understand-7.0.1213-7.0.dmg',
                                                       'pkginfo_path': 'apps/Understand-7.0.plist',
                                                       'version': '7.0'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 26, 4, 12, 26),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'category': 'Science',
                           'description': 'Understand provides you with '
                                          'pertinent information regarding '
                                          'your code.',
                           'developer': 'Scientific Toolworks',
                           'display_name': 'Understand',
                           'installer_item_hash': '35752a6bfc38d06838e650b42071280d66b58f7732b987e858ac9b6409ac2fe8',
                           'installer_item_location': 'apps/Understand-7.0.1213-7.0.dmg',
                           'installer_item_size': 702684,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.scitools.Understand',
                                         'CFBundleName': 'Understand',
                                         'CFBundleShortVersionString': '7.0',
                                         'CFBundleVersion': '1213',
                                         'path': '/Applications/Understand.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'Understand.app'}],
                           'minimum_os_version': '10.4.0',
                           'name': 'Understand',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '7.0'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Understand-7.0.1213-7.0.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/Understand-7.0.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gerardkok.munki.Understand/receipts/Understand.munki-receipt-20241225-201226.plist
Processing Understand/Understand.pkg.recipe...
WARNING: Understand/Understand.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '(https://latest.scitools.com/Understand/Understand-(?P<version>[\\d\\.]+)-macOS-Universal.dmg)',
           'result_output_var_name': 'url',
           'url': 'https://licensing.scitools.com/download/thanks/macOS-Universal.dmg'}}
URLTextSearcher: Found matching text (version): 7.0.1213
URLTextSearcher: Found matching text (url): https://latest.scitools.com/Understand/Understand-7.0.1213-macOS-Universal.dmg
{'Output': {'url': 'https://latest.scitools.com/Understand/Understand-7.0.1213-macOS-Universal.dmg',
            'version': '7.0.1213'}}
URLDownloader
{'Input': {'filename': 'Understand-7.0.1213.dmg',
           'url': 'https://latest.scitools.com/Understand/Understand-7.0.1213-macOS-Universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 18 Dec 2024 23:34:29 GMT
URLDownloader: Storing new ETag header: "bebabb79c80956a2932ba77fd12e279e-86"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gerardkok.pkg.Understand/downloads/Understand-7.0.1213.dmg
{'Output': {'download_changed': True,
            'etag': '"bebabb79c80956a2932ba77fd12e279e-86"',
            'last_modified': 'Wed, 18 Dec 2024 23:34:29 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gerardkok.pkg.Understand/downloads/Understand-7.0.1213.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.pkg.Understand/downloads/Understand-7.0.1213.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.pkg.Understand/downloads/Understand-7.0.1213.dmg/Understand.app',
           'requirement': 'identifier "com.scitools.Understand" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'CNU9P2K643'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.gerardkok.pkg.Understand/downloads/Understand-7.0.1213.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.3OPzNL/Understand.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.3OPzNL/Understand.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.3OPzNL/Understand.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.pkg.Understand/downloads/Understand-7.0.1213.dmg/Understand.app',
           'version': '7.0.1213'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.gerardkok.pkg.Understand/downloads/Understand-7.0.1213.dmg
AppPkgCreator: BundleID: com.scitools.Understand
AppPkgCreator: Copied /private/tmp/dmg.wD4Esc/Understand.app to ~/Library/AutoPkg/Cache/com.github.gerardkok.pkg.Understand/payload/Applications/Understand.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.scitools.Understand',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.pkg.Understand/Understand-7.0.1213.pkg',
                                                        'version': '7.0.1213'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '7.0.1213'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gerardkok.pkg.Understand/receipts/Understand.pkg-receipt-20241225-201427.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.gerardkok.download.Understand/downloads/Understand-7.0.1213.dmg
    ~/Library/AutoPkg/Cache/com.github.gerardkok.munki.Understand/downloads/Understand-7.0.1213.dmg
    ~/Library/AutoPkg/Cache/com.github.gerardkok.pkg.Understand/downloads/Understand-7.0.1213.dmg

The following new items were imported into Munki:
    Name        Version  Catalogs  Pkginfo Path                  Pkg Repo Path                        Icon Repo Path
    ----        -------  --------  ------------                  -------------                        --------------
    Understand  7.0      testing   apps/Understand-7.0.plist  apps/Understand-7.0.1213-7.0.dmg

The following packages were built:
    Identifier               Version   Pkg Path
    ----------               -------   --------
    com.scitools.Understand  7.0.1213  ~/Library/AutoPkg/Cache/com.github.gerardkok.pkg.Understand/Understand-7.0.1213.pkg
```