### PR TITLE
Fix PDK recipes and add ARCH input variable

### DIFF
--- a/Puppet/PDK.download.recipe
+++ b/Puppet/PDK.download.recipe
@@ -3,7 +3,12 @@
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Download recipe for the Puppet Development Kit.</string>
+        <string>Download recipe for the Puppet Development Kit.
+        
+Valid values for ARCH include:
+- "x86_64" (default, Intel)
+- "arm64" (Apple Silicon)
+</string>
         <key>Identifier</key>
         <string>com.github.gerardkok.download.pdk</string>
         <key>Input</key>
@@ -11,7 +16,9 @@
             <key>NAME</key>
             <string>PDK</string>
             <key>OS_VERSION</key>
-		    <string>10.12</string>
+            <string>13</string>
+            <key>ARCH</key>
+            <string>x86_64</string>
         </dict>
         <key>MinimumVersion</key>
         <string>0.5.0</string>
@@ -21,7 +28,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>url</key>
-                    <string>https://pm.puppet.com/cgi-bin/pdk_download.cgi?dist=osx&amp;rel=%OS_VERSION%&amp;arch=x86_64&amp;ver=latest</string>
+                    <string>https://pm.puppet.com/cgi-bin/pdk_download.cgi?dist=osx&amp;rel=%OS_VERSION%&amp;arch=%ARCH%&amp;ver=latest</string>
                     <key>filename</key>
                     <string>%NAME%.dmg</string>
                 </dict>


### PR DESCRIPTION
This PR updates the default OS version for PDK downloads (10.12 is no longer available), and adds an ARCH input variable for specifying whether to download the Intel or Apple Silicon version of PDK.

Verbose recipe run output:

```
% autopkg run -vvq 'Puppet/PDK.download.recipe'
Processing Puppet/PDK.download.recipe...
WARNING: Puppet/PDK.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'PDK.dmg',
           'url': 'https://pm.puppet.com/cgi-bin/pdk_download.cgi?dist=osx&rel=13&arch=x86_64&ver=latest'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 03 Dec 2024 12:04:36 GMT
URLDownloader: Storing new ETag header: "2cb37823a1e0a0127673c06b05f4e7c8-15"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gerardkok.download.pdk/downloads/PDK.dmg
{'Output': {'download_changed': True,
            'etag': '"2cb37823a1e0a0127673c06b05f4e7c8-15"',
            'last_modified': 'Tue, 03 Dec 2024 12:04:36 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.pdk/downloads/PDK.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.pdk/downloads/PDK.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: PUPPET LABS, '
                                        'INC. (VKGLGN2B6Y)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.pdk/downloads/PDK.dmg/*.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.gerardkok.download.pdk/downloads/PDK.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.U8Uedl/pdk-3.4.0.1-1-installer.pkg' matched from globbed '/private/tmp/dmg.U8Uedl/*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "pdk-3.4.0.1-1-installer.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-11-29 13:20:45 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: PUPPET LABS, INC. (VKGLGN2B6Y)
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            E7 20 70 F7 45 FC 8C C1 AE FC 47 C3 9A C0 10 BB 2D F0 F3 2A BA A1
CodeSignatureVerifier:            E3 3D 63 61 3C 16 CB 63 BE 8E
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gerardkok.download.pdk/receipts/PDK.download-receipt-20241225-193742.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.gerardkok.download.pdk/downloads/PDK.dmg
```
