### PR TITLE
Fix MongoDB recipes and add ARCH input variable

### DIFF
--- a/MongoDB/MongoDB.download.recipe
+++ b/MongoDB/MongoDB.download.recipe
@@ -3,15 +3,20 @@
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Download recipe for MongoDB.</string>
+        <string>Download recipe for MongoDB.
+        
+Values for ARCH include:
+- "x86_64" (default, Intel)
+- "arm64" (Apple Silicon)
+</string>
         <key>Identifier</key>
         <string>com.github.gerardkok.download.MongoDB</string>
         <key>Input</key>
         <dict>
             <key>NAME</key>
             <string>MongoDB</string>
-            <key>URL</key>
-            <string>https://www.mongodb.com/try/download/community</string>
+            <key>ARCH</key>
+            <string>x86_64</string>
         </dict>
         <key>MinimumVersion</key>
         <string>0.3.1</string>
@@ -23,16 +28,18 @@
                 <key>Arguments</key>
                 <dict>
                     <key>url</key>
-                    <string>%URL%</string>
+                    <string>https://www.mongodb.com/try/download/community-edition/releases</string>
                     <key>re_pattern</key>
-                    <string>\"macOS\":{\"tgz\":\"(?P&lt;url&gt;https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-(?P&lt;version&gt;[0-9\.]+).tgz)\"}</string>
+                    <string>"(https://fastdl.mongodb.org/osx/mongodb-macos-%ARCH%-(?P&lt;version&gt;[\d\.]+)\.tgz)"</string>
+                    <key>result_output_var_name</key>
+                    <string>url</string>
                 </dict>
             </dict>
             <dict>
                 <key>Arguments</key>
                 <dict>
                     <key>filename</key>
-                    <string>%NAME%.tgz</string>
+                    <string>%NAME%-%version%-%ARCH%.tgz</string>
                 </dict>
                 <key>Processor</key>
                 <string>URLDownloader</string>

--- a/MongoDB/MongoDB.munki.recipe
+++ b/MongoDB/MongoDB.munki.recipe
@@ -33,6 +33,10 @@
                 <key>display_name</key>
                 <string>MongoDB</string>
                 <key>name</key>
+                <key>supported_architectures</key>
+                <array>
+                    <string>%ARCH%</string>
+                </array>
                 <string>%NAME%</string>
                 <key>unattended_install</key>
                 <true/>

--- a/MongoDB/MongoDB.pkg.recipe
+++ b/MongoDB/MongoDB.pkg.recipe
@@ -89,7 +89,7 @@
                         <key>pkgdir</key>
                         <string>%RECIPE_CACHE_DIR%</string>
                         <key>pkgname</key>
-                        <string>%NAME%-%version%</string>
+                        <string>%NAME%-%version%-%ARCH%</string>
                         <key>id</key>
                         <string>%PKG_ID%</string>
                         <key>version</key>


### PR DESCRIPTION
This PR updates the pattern used to download the Mac version of MongoDB. It also adds an input variable that can be used to specify which architecture to download.

Verbose recipe run with default Intel architecture:

```
% autopkg run -vvq 'MongoDB/MongoDB.download.recipe'
Processing MongoDB/MongoDB.download.recipe...
WARNING: MongoDB/MongoDB.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '"(https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-(?P<version>[\\d\\.]+)\\.tgz)"',
           'result_output_var_name': 'url',
           'url': 'https://www.mongodb.com/try/download/community-edition/releases'}}
URLTextSearcher: Found matching text (version): 8.0.4
URLTextSearcher: Found matching text (url): https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-8.0.4.tgz
{'Output': {'url': 'https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-8.0.4.tgz',
            'version': '8.0.4'}}
URLDownloader
{'Input': {'filename': 'MongoDB-8.0.4-x86_64.tgz',
           'url': 'https://fastdl.mongodb.org/osx/mongodb-macos-x86_64-8.0.4.tgz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 28 Nov 2024 11:57:16 GMT
URLDownloader: Storing new ETag header: "17e8243035bedf40a98c826040e7fb97"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gerardkok.download.MongoDB/downloads/MongoDB-8.0.4-x86_64.tgz
{'Output': {'download_changed': True,
            'etag': '"17e8243035bedf40a98c826040e7fb97"',
            'last_modified': 'Thu, 28 Nov 2024 11:57:16 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.MongoDB/downloads/MongoDB-8.0.4-x86_64.tgz',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.MongoDB/downloads/MongoDB-8.0.4-x86_64.tgz'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gerardkok.download.MongoDB/receipts/MongoDB.download-receipt-20241225-184125.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.gerardkok.download.MongoDB/downloads/MongoDB-8.0.4-x86_64.tgz
```

Verbose recipe run with Apple Silicon architecture:

```
% autopkg run -vvq 'MongoDB/MongoDB.download.recipe' -k ARCH=arm64
Processing MongoDB/MongoDB.download.recipe...
WARNING: MongoDB/MongoDB.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': '"(https://fastdl.mongodb.org/osx/mongodb-macos-arm64-(?P<version>[\\d\\.]+)\\.tgz)"',
           'result_output_var_name': 'url',
           'url': 'https://www.mongodb.com/try/download/community-edition/releases'}}
URLTextSearcher: Found matching text (version): 8.0.4
URLTextSearcher: Found matching text (url): https://fastdl.mongodb.org/osx/mongodb-macos-arm64-8.0.4.tgz
{'Output': {'url': 'https://fastdl.mongodb.org/osx/mongodb-macos-arm64-8.0.4.tgz',
            'version': '8.0.4'}}
URLDownloader
{'Input': {'filename': 'MongoDB-8.0.4-arm64.tgz',
           'url': 'https://fastdl.mongodb.org/osx/mongodb-macos-arm64-8.0.4.tgz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 27 Nov 2024 22:58:27 GMT
URLDownloader: Storing new ETag header: "1565f93a225e4c9bb2df5cc471299d8b"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gerardkok.download.MongoDB/downloads/MongoDB-8.0.4-arm64.tgz
{'Output': {'download_changed': True,
            'etag': '"1565f93a225e4c9bb2df5cc471299d8b"',
            'last_modified': 'Wed, 27 Nov 2024 22:58:27 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.MongoDB/downloads/MongoDB-8.0.4-arm64.tgz',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.MongoDB/downloads/MongoDB-8.0.4-arm64.tgz'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gerardkok.download.MongoDB/receipts/MongoDB.download-receipt-20241225-184139.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.gerardkok.download.MongoDB/downloads/MongoDB-8.0.4-arm64.tgz
```
