### PR TITLE
Fix Crystal recipes

### DIFF
--- a/Crystal/Crystal.download.recipe
+++ b/Crystal/Crystal.download.recipe
@@ -21,7 +21,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>asset_regex</key>
-                    <string>crystal-[0-9\.\-]+\.pkg</string>
+                    <string>crystal-[\d\.\-]+\.universal\.pkg</string>
                     <key>github_repo</key>
                     <string>crystal-lang/crystal</string>
                 </dict>


### PR DESCRIPTION
This PR updates the asset regex pattern used by Crystal.download.

Verbose recipe run output:

```
% autopkg run -vvq 'Crystal/Crystal.download.recipe'
Processing Crystal/Crystal.download.recipe...
WARNING: Crystal/Crystal.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'crystal-[0-9\\.\\-]+\\.universal\\.pkg',
           'github_repo': 'crystal-lang/crystal'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'crystal-[0-9\.\-]+\.universal\.pkg' among asset(s): crystal-1.14.0-1-darwin-universal.tar.gz, crystal-1.14.0-1-linux-x86_64-bundled.tar.gz, crystal-1.14.0-1-linux-x86_64.tar.gz, crystal-1.14.0-1.universal.pkg, crystal-1.14.0-docs.tar.gz, crystal-1.14.0-windows-x86_64-msvc-unsupported.exe, crystal-1.14.0-windows-x86_64-msvc-unsupported.zip
GitHubReleasesInfoProvider: Selected asset 'crystal-1.14.0-1.universal.pkg' from release '1.14.0'
{'Output': {'asset_created_at': '2024-10-09T12:33:59Z',
            'asset_url': 'https://api.github.com/repos/crystal-lang/crystal/releases/assets/197907723',
            'release_notes': '### Features\r\n'
[...snip...]
            'url': 'https://github.com/crystal-lang/crystal/releases/download/1.14.0/crystal-1.14.0-1.universal.pkg',
            'version': '1.14.0'}}
URLDownloader
{'Input': {'filename': 'Crystal.pkg',
           'url': 'https://github.com/crystal-lang/crystal/releases/download/1.14.0/crystal-1.14.0-1.universal.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 09 Oct 2024 12:35:11 GMT
URLDownloader: Storing new ETag header: "0x8DCE85ED171673D"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gerardkok.download.Crystal/downloads/Crystal.pkg
{'Output': {'download_changed': True,
            'etag': '"0x8DCE85ED171673D"',
            'last_modified': 'Wed, 09 Oct 2024 12:35:11 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.Crystal/downloads/Crystal.pkg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.Crystal/downloads/Crystal.pkg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gerardkok.download.Crystal/receipts/Crystal.download-receipt-20241225-181602.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.gerardkok.download.Crystal/downloads/Crystal.pkg
```
