### PR TITLE
Remove empty `expected_authority_names` array in CodeSignatureVerifier arguments

### DIFF
--- a/ClickShare/ClickShareLauncher.pkg.recipe
+++ b/ClickShare/ClickShareLauncher.pkg.recipe
@@ -78,8 +78,6 @@
                     <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/ClickShare Launcher.app</string>
                     <key>requirement</key>
                     <string>identifier "com.barco.clicksharelauncher" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = P6CDJZR997</string>
-                    <key>expected_authority_names</key>
-                    <array/>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
As long as there is a valid `requirements` argument, the `expected_authority_names` argument is not needed for code signature verification. This pull request removes the unnecessary empty `expected_authority_names` array.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.