### PR TITLE
Fix MongoDB.munki.recipe

### DIFF
--- a/MongoDB/MongoDB.munki.recipe
+++ b/MongoDB/MongoDB.munki.recipe
@@ -33,11 +33,11 @@
                 <key>display_name</key>
                 <string>MongoDB</string>
                 <key>name</key>
+                <string>%NAME%</string>
                 <key>supported_architectures</key>
                 <array>
                     <string>%ARCH%</string>
                 </array>
-                <string>%NAME%</string>
                 <key>unattended_install</key>
                 <true/>
             </dict>


### PR DESCRIPTION
We're seeing errors with the latest change to the MongoDB.munki.recipe:

```
com.github.autopkg.gerardkok-recipes/MongoDB/MongoDB.munki.recipe: unexpected key at line 36
```