### PR TITLE
Remove USER_AGENT

### DIFF
--- a/MySQL/MySQLCommunityServer.download.recipe
+++ b/MySQL/MySQLCommunityServer.download.recipe
@@ -15,8 +15,6 @@
             <key>ARCHITECTURE</key>
             <!-- x86_64 or arm64 -->
             <string>x86_64</string>
-            <key>USER_AGENT</key>
-            <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15</string>
         </dict>
         <key>MinimumVersion</key>
         <string>0.3.1</string>
@@ -31,11 +29,6 @@
                     <string>https://dev.mysql.com/downloads/mysql/%RELEASE%.html</string>
                     <key>re_pattern</key>
                     <string>\((?P&lt;rel_url&gt;mysql-(?P&lt;version&gt;[0-9\.]+)-.*-).*?dmg\)</string>
-                    <key>request_headers</key>
-                    <dict>
-                        <key>user-agent</key>
-                        <string>%USER_AGENT%</string>
-                    </dict>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
It appears that MySQL is performing a user agent verification before the page will load and returns a 403 error if anything seems wrong. In my testing, using the default curl user agent appears to work on all systems.