### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/1Password/1PasswordCLI.pkg.recipe
+++ b/1Password/1PasswordCLI.pkg.recipe
@@ -78,8 +78,6 @@
                         <string>%PKG_ID%</string>
                         <key>version</key>
                         <string>%version%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>

--- a/ClickShare/ClickShareLauncher.pkg.recipe
+++ b/ClickShare/ClickShareLauncher.pkg.recipe
@@ -108,8 +108,6 @@
                         <string>%PKG_ID%</string>
                         <key>version</key>
                         <string>%version%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                     </dict>
                 </dict>
             </dict>

--- a/Helm/Helm.pkg.recipe
+++ b/Helm/Helm.pkg.recipe
@@ -69,8 +69,6 @@
                         <string>%PKG_ID%</string>
                         <key>version</key>
                         <string>%version%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>

--- a/MongoDB/MongoDB.pkg.recipe
+++ b/MongoDB/MongoDB.pkg.recipe
@@ -94,8 +94,6 @@
                         <string>%PKG_ID%</string>
                         <key>version</key>
                         <string>%version%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>

--- a/Python-package/Python-package.pkg.recipe
+++ b/Python-package/Python-package.pkg.recipe
@@ -100,8 +100,6 @@ fi
                         <string>com.github.autopkg.gerardkok-recipes.%NAME%</string>
                         <key>version</key>
                         <string>%version%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                     </dict>
                 </dict>
             </dict>

--- a/Splunk/SplunkForwarder.pkg.recipe
+++ b/Splunk/SplunkForwarder.pkg.recipe
@@ -61,8 +61,6 @@
                         <string>%PKG_ID%</string>
                         <key>version</key>
                         <string>%version%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>

--- a/Yarn/Yarn.pkg.recipe
+++ b/Yarn/Yarn.pkg.recipe
@@ -91,8 +91,6 @@
                         <string>%PKG_ID%</string>
                         <key>version</key>
                         <string>%version%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>

--- a/argocd/argocd.pkg.recipe
+++ b/argocd/argocd.pkg.recipe
@@ -67,8 +67,6 @@
                         <string>%PKG_ID%</string>
                         <key>version</key>
                         <string>%version%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>

--- a/jq/jq.pkg.recipe
+++ b/jq/jq.pkg.recipe
@@ -81,8 +81,6 @@
 					<false/>
 					<key>id</key>
 					<string>%PKG_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
 					<key>pkgname</key>

--- a/k9s/k9s.pkg.recipe
+++ b/k9s/k9s.pkg.recipe
@@ -67,8 +67,6 @@
                         <string>%PKG_ID%</string>
                         <key>version</key>
                         <string>%version%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>

--- a/kubeseal/kubeseal.pkg.recipe
+++ b/kubeseal/kubeseal.pkg.recipe
@@ -67,8 +67,6 @@
                         <string>%PKG_ID%</string>
                         <key>version</key>
                         <string>%version%</string>
-                        <key>options</key>
-                        <string>purge_ds_store</string>
                         <key>chown</key>
                         <array>
                             <dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._