### PR TITLE
Fix Postbox download pattern

### DIFF
--- a/Postbox/Postbox.download.recipe
+++ b/Postbox/Postbox.download.recipe
@@ -23,7 +23,7 @@
                     <key>url</key>
                     <string>https://www.postbox-inc.com/download/success-mac</string>
                     <key>re_pattern</key>
-                    <string>\"(?P&lt;download_url&gt;https://.*\.dmg)\"</string>
+                    <string>href=\"(?P&lt;download_url&gt;https://.*\.dmg)\"</string>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
There's an iframe URL that exists on the Postbox download page prior to the actual dmg URL we want, and it seems to have a typo in it that sends us to a 403.

This PR fixes that by focusing on the correct hypertext reference object rather than the earlier iframe object.

```
% autopkg run -vvq 'gerardkok-recipes/Postbox/Postbox.download.recipe'
Processing gerardkok-recipes/Postbox/Postbox.download.recipe...
WARNING: gerardkok-recipes/Postbox/Postbox.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href=\\"(?P<download_url>https://.*\\.dmg)\\"',
           'url': 'https://www.postbox-inc.com/download/success-mac'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (download_url): https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-7.0.65-mac64.dmg
URLTextSearcher: Found matching text (match): https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-7.0.65-mac64.dmg
{'Output': {'download_url': 'https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-7.0.65-mac64.dmg',
            'match': 'https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-7.0.65-mac64.dmg'}}
URLDownloader
{'Input': {'filename': 'Postbox.dmg',
           'url': 'https://d3nx85trn0lqsg.cloudfront.net/mac/postbox-7.0.65-mac64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sun, 15 Dec 2024 00:59:29 GMT
URLDownloader: Storing new ETag header: "1cac0bbe961a4db882bd77d49f956961-8"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.gerardkok.download.Postbox/downloads/Postbox.dmg
{'Output': {'download_changed': True,
            'etag': '"1cac0bbe961a4db882bd77d49f956961-8"',
            'last_modified': 'Sun, 15 Dec 2024 00:59:29 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.Postbox/downloads/Postbox.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.Postbox/downloads/Postbox.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.gerardkok.download.Postbox/downloads/Postbox.dmg/Postbox.app',
           'requirement': 'identifier "com.postbox-inc.postbox" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'A9QD7F9VSC'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.gerardkok.download.Postbox/downloads/Postbox.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.glkltM/Postbox.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.glkltM/Postbox.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.glkltM/Postbox.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.gerardkok.download.Postbox/receipts/Postbox.download-receipt-20251115-091557.plist

The following new items were downloaded:
    Download Path                                                                                    
    -------------                                                                                    
    ~/Library/AutoPkg/Cache/com.github.gerardkok.download.Postbox/downloads/Postbox.dmg
```