### PR TITLE
Add checksum_pathname to download recipe

### DIFF
--- a/Helm/Helm.download.recipe
+++ b/Helm/Helm.download.recipe
@@ -50,6 +50,8 @@
                     <string>SHA256</string>
                     <key>checksum</key>
                     <string>%checksum%</string>
+                    <key>checksum_pathname</key>
+                    <string>%pathname%</string>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
Hi, @gerardkok 

This PR adds the now required `checksum_pathname` key to the `ChecksumVerifier` processor due to this PR autopkg/hjuutilainen-recipes#303 being merged to address autopkg/hjuutilainen-recipes#271

The recipe will currently fail with 
```
The following recipes failed:
    elasticbeat.download.recipe
        io.github.hjuutilainen.SharedProcessors/ChecksumVerifier requires missing argument checksum_pathname

Nothing downloaded, packaged or imported.
```

Output from a successful -v run 
```
autopkg run -v Helm.download.recipe 
Processing Helm.download.recipe...
WARNING: Helm.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (url): https://get.helm.sh/helm-v4.0.1-darwin-amd64.tar.gz
URLTextSearcher: Found matching text (version): 4.0.1
URLTextSearcher: Found matching text (checksum): a8d1ca46c3ff5484b2b635dfc25832add4f36fdd09cf2a36fb709829c05b4112
URLTextSearcher: Found matching text (match): a8d1ca46c3ff5484b2b635dfc25832add4f36fdd09cf2a36fb709829c05b4112
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 24 Nov 2025 20:16:37 GMT
URLDownloader: Storing new ETag header: 0x8DE2B965F216619
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gerardkok.download.Helm/downloads/Helm.tar.gz
EndOfCheckPhase
io.github.hjuutilainen.SharedProcessors/ChecksumVerifier
ChecksumVerifier: Calculating SHA256 checksum for /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gerardkok.download.Helm/downloads/Helm.tar.gz
ChecksumVerifier: Calculated checksum: a8d1ca46c3ff5484b2b635dfc25832add4f36fdd09cf2a36fb709829c05b4112
ChecksumVerifier: Expected checksum:   a8d1ca46c3ff5484b2b635dfc25832add4f36fdd09cf2a36fb709829c05b4112
ChecksumVerifier: Calculated checksum matches the expected checksum.
Unarchiver
Unarchiver: Guessed archive format 'tar_gzip' from filename Helm.tar.gz
Unarchiver: Unarchived /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gerardkok.download.Helm/downloads/Helm.tar.gz to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gerardkok.download.Helm/unpacked
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gerardkok.download.Helm/receipts/Helm.download-receipt-20251208-175004.plist

The following new items were downloaded:
    Download Path                                                                                      
    -------------                                                                                      
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.gerardkok.download.Helm/downloads/Helm.tar.gz
```

Please also make sure to update https://github.com/autopkg/hjuutilainen-recipes to get the latest version of `ChecksumVerifier`