### PR TITLE
Update Helm recipes

### DIFF
--- a/Helm/Helm.download.recipe
+++ b/Helm/Helm.download.recipe
@@ -3,20 +3,35 @@
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Downloads the latest version of the Helm CLI.</string>
+        <string>Downloads the latest version of the Helm CLI. Set ARCH to either arm64 or x86_64.</string>
         <key>Identifier</key>
         <string>com.github.gerardkok.download.Helm</string>
         <key>Input</key>
         <dict>
             <key>NAME</key>
             <string>Helm</string>
-            <key>PLATFORM_ARCH</key>
-            <string>amd64</string>
+            <key>ARCH</key>
+            <string>arm64</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>0.3.1</string>
+        <string>2.7.6</string>
         <key>Process</key>
         <array>
+            <dict>
+                <key>Processor</key>
+                <string>FindAndReplace</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>find</key>
+                    <string>x86_64</string>
+                    <key>input_string</key>
+                    <string>%ARCH%</string>
+                    <key>replace</key>
+                    <string>amd64</string>
+                    <key>result_output_var_name</key>
+                    <string>PLATFORM_ARCH</string>
+                </dict>
+            </dict>
             <dict>
                 <key>Processor</key>
                 <string>URLTextSearcher</string>
@@ -29,13 +44,13 @@
                 </dict>
             </dict>
             <dict>
+                <key>Processor</key>
+                <string>URLDownloader</string>
                 <key>Arguments</key>
                 <dict>
                     <key>filename</key>
                     <string>%NAME%.tar.gz</string>
                 </dict>
-                <key>Processor</key>
-                <string>URLDownloader</string>
             </dict>
             <dict>
                 <key>Processor</key>
@@ -52,19 +67,6 @@
                     <string>%checksum%</string>
                     <key>checksum_pathname</key>
                     <string>%pathname%</string>
-                </dict>
-            </dict>
-            <dict>
-                <key>Processor</key>
-                <string>Unarchiver</string>
-                <key>Arguments</key>
-                <dict>
-                    <key>archive_path</key>
-                    <string>%pathname%</string>
-                    <key>destination_path</key>
-                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
-                    <key>purge_destination</key>
-                    <true/>
                 </dict>
             </dict>
         </array>

--- a/Helm/Helm.munki.recipe
+++ b/Helm/Helm.munki.recipe
@@ -3,21 +3,21 @@
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Downloads the current release version of Helm and imports into Munki.</string>
+        <string>Downloads the current release version of Helm and imports into Munki. Set ARCH to either arm64 or x86_64.</string>
         <key>Identifier</key>
         <string>com.github.gerardkok.munki.Helm</string>
         <key>Input</key>
         <dict>
+            <key>ARCH</key>
+            <string>arm64</string>
             <key>NAME</key>
             <string>Helm</string>
             <key>MUNKI_REPO_SUBDIR</key>
-            <string>apps/%NAME%</string>
+            <string>apps/%NAME%/%ARCH%</string>
             <key>MUNKI_CATEGORY</key>
             <string>Development</string>
             <key>PKG_ID</key>
             <string>sh.helm.helm</string>
-            <key>PLATFORM_ARCH</key>
-            <string>amd64</string>
             <key>pkginfo</key>
             <dict>
                 <key>catalogs</key>
@@ -32,9 +32,17 @@
                 <string>Cloud Native Computing Foundation</string>
                 <key>display_name</key>
                 <string>%NAME%</string>
+                <key>minimum_os_version</key>
+                <string>12.0</string>
                 <key>name</key>
                 <string>%NAME%</string>
+                <key>supported_architectures</key>
+                <array>
+                    <string>%ARCH%</string>
+                </array>
                 <key>unattended_install</key>
+                <true/>
+                <key>unattended_uninstall</key>
                 <true/>
             </dict>
         </dict>
@@ -45,6 +53,25 @@
         <key>Process</key>
         <array>
             <dict>
+                <key>Processor</key>
+                <string>MunkiInstallsItemsCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>faux_root</key>
+                    <string>%RECIPE_CACHE_DIR%/payload</string>
+                    <key>installs_item_paths</key>
+                    <array>
+                        <string>/usr/local/bin/helm</string>
+                    </array>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
+                <string>MunkiPkginfoMerger</string>
+            </dict>
+            <dict>
+                <key>Processor</key>
+                <string>MunkiImporter</string>
                 <key>Arguments</key>
                 <dict>
                     <key>pkg_path</key>
@@ -52,8 +79,18 @@
                     <key>repo_subdirectory</key>
                     <string>%MUNKI_REPO_SUBDIR%</string>
                 </dict>
+            </dict>
+            <dict>
                 <key>Processor</key>
-                <string>MunkiImporter</string>
+                <string>PathDeleter</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>path_list</key>
+                    <array>
+                        <string>%RECIPE_CACHE_DIR%/payload</string>
+                        <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                    </array>
+                </dict>
             </dict>
         </array>
     </dict>

--- a/Helm/Helm.munki.recipe
+++ b/Helm/Helm.munki.recipe
@@ -44,6 +44,9 @@
                 <true/>
                 <key>unattended_uninstall</key>
                 <true/>
+                <key>version_script</key>
+                <string>#!/bin/sh
+/usr/local/bin/helm version | /usr/bin/awk 'match($0,/Version:"v[^"]*/){print substr($0,RSTART+10,RLENGTH-10); exit}'</string>
             </dict>
         </dict>
         <key>MinimumVersion</key>

--- a/Helm/Helm.pkg.recipe
+++ b/Helm/Helm.pkg.recipe
@@ -3,17 +3,17 @@
 <plist version="1.0">
     <dict>
         <key>Description</key>
-        <string>Builds a package that installs Helm.</string>
+        <string>Builds a package that installs Helm. Set ARCH to either arm64 or x86_64.</string>
         <key>Identifier</key>
         <string>com.github.gerardkok.pkg.Helm</string>
         <key>Input</key>
         <dict>
             <key>NAME</key>
             <string>Helm</string>
+            <key>ARCH</key>
+            <string>arm64</string>
             <key>PKG_ID</key>
             <string>sh.helm.helm</string>
-            <key>PLATFORM_ARCH</key>
-            <string>amd64</string>
         </dict>
         <key>MinimumVersion</key>
         <string>0.2.0</string>
@@ -23,20 +23,31 @@
         <array>
             <dict>
                 <key>Processor</key>
+                <string>Unarchiver</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>archive_path</key>
+                    <string>%pathname%</string>
+                    <key>destination_path</key>
+                    <string>%RECIPE_CACHE_DIR%/unpacked</string>
+                    <key>purge_destination</key>
+                    <true/>
+                </dict>
+            </dict>
+            <dict>
+                <key>Processor</key>
                 <string>PkgRootCreator</string>
                 <key>Arguments</key>
                 <dict>
                     <key>pkgroot</key>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                    <string>%RECIPE_CACHE_DIR%/payload</string>
                     <key>pkgdirs</key>
                     <dict>
-                        <key>payload</key>
+                        <key>usr</key>
                         <string>0755</string>
-                        <key>payload/usr</key>
+                        <key>usr/local</key>
                         <string>0755</string>
-                        <key>payload/usr/local</key>
-                        <string>0755</string>
-                        <key>payload/usr/local/bin</key>
+                        <key>usr/local/bin</key>
                         <string>0755</string>
                     </dict>
                 </dict>
@@ -47,9 +58,9 @@
                 <key>Arguments</key>
                 <dict>
                     <key>source_path</key>
-                    <string>%RECIPE_CACHE_DIR%/unpacked/darwin-%PLATFORM_ARCH%/helm</string>
+                    <string>%RECIPE_CACHE_DIR%/unpacked/*/helm</string>
                     <key>destination_path</key>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%/payload/usr/local/bin/helm</string>
+                    <string>%RECIPE_CACHE_DIR%/payload/usr/local/bin/helm</string>
                 </dict>
             </dict>
             <dict>
@@ -60,9 +71,9 @@
                     <key>pkg_request</key>
                     <dict>
                         <key>pkgroot</key>
-                        <string>%RECIPE_CACHE_DIR%/%NAME%/payload</string>
+                        <string>%RECIPE_CACHE_DIR%/payload</string>
                         <key>pkgdir</key>
-                        <string>%RECIPE_CACHE_DIR%/%NAME%</string>
+                        <string>%RECIPE_CACHE_DIR%</string>
                         <key>pkgname</key>
                         <string>%NAME%-%version%</string>
                         <key>id</key>


### PR DESCRIPTION
This updates the Helm recipes with several changes:

**Helm.download.recipe**
- Switches to a single ARCH variable that can be used for both the download and Munki's supported_architectures array
- Uses the FindAndReplace processor to swap x86_64 for amd64 when downloading
- Moves the Unarchiver processor to the pkg recipe where it is needed

**Helm.pkg.recipe**
- Adds the Unarchiver processor previously in the download recipe
- Simplifies the payload directories
- Switches to a wildcard in the Copier recipe for simplicity

**Helm.munki.recipe**
- Adds minimum_os_support key
- Adds supported_architectures array
- Adds an installs array
- Adds PathDeleter processor to cleanup afterwards
- Adds version_script key

**Logs**
-vv runs for each architecture:
[Helm.arm64.txt](https://github.com/user-attachments/files/24461504/Helm.arm64.txt)
[Helm.x86_64.txt](https://github.com/user-attachments/files/24461505/Helm.x86_64.txt)