### PR TITLE
Helm notes; fix XML

### DIFF
--- a/1Password/1PasswordCLI.munki.recipe
+++ b/1Password/1PasswordCLI.munki.recipe
@@ -44,7 +44,6 @@
         <string>com.github.gerardkok.pkg.1PasswordCLI</string>
         <key>Process</key>
         <array>
-        <dict>
             <dict>
                 <key>Processor</key>
                 <string>DeprecationWarning</string>
@@ -54,16 +53,17 @@
                     <string>This recipe will be removed on July 19, 2026.</string>
                 </dict>
             </dict>
-            <key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-            <key>Arguments</key>
             <dict>
-                <key>additional_pkginfo</key>
+                <key>Processor</key>
+                <string>MunkiPkginfoMerger</string>
+                <key>Arguments</key>
                 <dict>
-                    <key>version</key>
-                    <string>%version%</string>
+                    <key>additional_pkginfo</key>
+                    <dict>
+                        <key>version</key>
+                        <string>%version%</string>
+                    </dict>
                 </dict>
-            </dict>
             </dict>
             <dict>
                 <key>Arguments</key>

--- a/Airfoil/Airfoil.munki.recipe
+++ b/Airfoil/Airfoil.munki.recipe
@@ -57,7 +57,6 @@ fi
         <string>com.github.gerardkok.download.airfoil</string>
         <key>Process</key>
         <array>
-        <dict>
             <dict>
                 <key>Processor</key>
                 <string>DeprecationWarning</string>
@@ -67,27 +66,28 @@ fi
                     <string>This recipe will be removed on July 19, 2026.</string>
                 </dict>
             </dict>
-            <key>Processor</key>
-            <string>PathDeleter</string>
-            <key>Arguments</key>
             <dict>
-                <key>path_list</key>
-                <array>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%/Airfoil Satellite.app</string>
-                </array>
+                <key>Processor</key>
+                <string>PathDeleter</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>path_list</key>
+                    <array>
+                        <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%/Airfoil Satellite.app</string>
+                    </array>
+                </dict>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>DmgCreator</string>
-            <key>Arguments</key>
             <dict>
-                <key>dmg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
-                <key>dmg_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%</string>
+                <key>Processor</key>
+                <string>DmgCreator</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>dmg_path</key>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                    <key>dmg_root</key>
+                    <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%</string>
+                </dict>
             </dict>
-        </dict>
             <dict>
                 <key>Processor</key>
                 <string>MunkiImporter</string>

--- a/Helm/Helm.download.recipe
+++ b/Helm/Helm.download.recipe
@@ -23,7 +23,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>warning_message</key>
-                    <string>This recipe will be removed on July 19, 2026.</string>
+                    <string>This recipe will be removed on July 19, 2026. Switch to com.github.kevinmcox.download.Helm</string>
                 </dict>
             </dict>
             <dict>

--- a/Helm/Helm.munki.recipe
+++ b/Helm/Helm.munki.recipe
@@ -61,7 +61,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>warning_message</key>
-                    <string>This recipe will be removed on July 19, 2026.</string>
+                    <string>This recipe will be removed on July 19, 2026. Switch to com.github.kevinmcox.munki.Helm</string>
                 </dict>
             </dict>
             <dict>

--- a/Helm/Helm.pkg.recipe
+++ b/Helm/Helm.pkg.recipe
@@ -27,7 +27,7 @@
                 <key>Arguments</key>
                 <dict>
                     <key>warning_message</key>
-                    <string>This recipe will be removed on July 19, 2026.</string>
+                    <string>This recipe will be removed on July 19, 2026. Switch to com.github.kevinmcox.pkg.Helm</string>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
Adds a note for the Helm recipes to point to new parents.

Fixes two recipes that had malformed XML after the deprecation notice was added.